### PR TITLE
REF: wrap providers.json install in try/except

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,17 @@ import versioneer
 
 
 # store the source JSON in `share/xyzservices`
-datadir = os.path.join(sys.prefix, "share", "xyzservices")
-if not os.path.exists(datadir):
-    os.makedirs(datadir)
+try:
+    datadir = os.path.join(sys.prefix, "share", "xyzservices")
+    if not os.path.exists(datadir):
+        os.makedirs(datadir)
 
-shutil.copyfile(
-    "./xyzservices/data/providers.json",
-    os.path.join(datadir, "providers.json"),
-)
+    shutil.copyfile(
+        "./xyzservices/data/providers.json",
+        os.path.join(datadir, "providers.json"),
+    )
+except Exception:
+    pass
 
 
 with open("README.md", "r", encoding="utf8") as fh:


### PR DESCRIPTION
In cases this fails, we can still use `providers.json` embedded in the library. There is a fallback for that on import. But the copy of `providers.json` to `share` on installation may fail and we don't want it to fail the installation itself.