### PR TITLE
GHA: add release action

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -1,0 +1,60 @@
+name: Publish xyzservices to PyPI / GitHub
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build-n-publish:
+    name: Build and publish xyzservices to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+          python setup.py sdist bdist_wheel
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Get Asset name
+        run: |
+          export PKG=$(ls dist/ | grep tar)
+          set -- $PKG
+          echo "name=$1" >> $GITHUB_ENV
+
+      - name: Upload Release Asset (sdist) to GitHub
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ env.name }}
+          asset_name: ${{ env.name }}
+          asset_content_type: application/zip

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -3,7 +3,7 @@ name: Publish xyzservices to PyPI / GitHub
 on:
   push:
     tags:
-      - "*"
+      - "2*"
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Adding GHA that automatically releases `xyservices` to GitHub and PyPI. It is the same one we use in geopandas and dask-geopandas using my PyPI token.

It will create a release from any tag starting with 2 (e.g. 2021.08) following #26.