### PR TITLE
GHA: commit compressed providers to PRs

### DIFF
--- a/.github/workflows/compress_providers.yaml
+++ b/.github/workflows/compress_providers.yaml
@@ -1,0 +1,38 @@
+name: Compress providers
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  compress:
+    if: ${{ github.event.label.name == 'community_contribution' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        environment-file: [ci/update_providers.yaml]
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+
+    - name: setup micromamba
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+        environment-file: ${{ matrix.environment-file }}
+        micromamba-version: 'latest'
+
+    - name: Parse leaflet providers/compress output
+      shell: bash -l {0}
+      run: |
+        make compress
+
+    - name: Commit files
+      run: |
+        git config --global user.name 'Martin Fleischmann'
+        git config --global user.email 'martinfleis@users.noreply.github.com'
+        git add xyzservices/data/providers.json
+        git commit -am "Compress JSON [automated]"
+        git push
+


### PR DESCRIPTION
Automatically runs `make compress` and commits the result to a PR labelled `community_contribution`.