### PR TITLE
CI: xfail qms tests

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -215,12 +215,13 @@ def test_html_attribution_fallback():
     )
 
 
+@pytest.mark.xfail(reason="timeout error")
 def test_from_qms():
     provider = TileProvider.from_qms("OpenStreetMap Standard aka Mapnik")
     assert isinstance(provider, TileProvider)
 
 
+@pytest.mark.xfail(reason="timeout error")
 def test_from_qms_not_found_error():
     with pytest.raises(ValueError):
         provider = TileProvider.from_qms("LolWut")
-


### PR DESCRIPTION
It seems that CI may occasionally fail while fetching data from QMS (https://github.com/geopandas/xyzservices/runs/3266305686). Marking with `xfail` to ensure it does not cause CI failure.