### PR TITLE
CI: xfail qms only on URLError

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,4 +1,5 @@
 import pytest
+from urllib.error import URLError
 
 import xyzservices.providers as xyz
 from xyzservices import TileProvider, Bunch
@@ -215,13 +216,13 @@ def test_html_attribution_fallback():
     )
 
 
-@pytest.mark.xfail(reason="timeout error")
+@pytest.mark.xfail(reason="timeout error", raises=URLError)
 def test_from_qms():
     provider = TileProvider.from_qms("OpenStreetMap Standard aka Mapnik")
     assert isinstance(provider, TileProvider)
 
 
-@pytest.mark.xfail(reason="timeout error")
+@pytest.mark.xfail(reason="timeout error", raises=URLError)
 def test_from_qms_not_found_error():
     with pytest.raises(ValueError):
         provider = TileProvider.from_qms("LolWut")


### PR DESCRIPTION
follow-up on #72 to ensure the test fails if any other error than `URLError` is raised.