### PR TITLE
ENH: add `fill_subdomain` keyword to `build_url`

### DIFF
--- a/xyzservices/lib.py
+++ b/xyzservices/lib.py
@@ -214,6 +214,7 @@ class TileProvider(Bunch):
         y: Optional[int] = None,
         z: Optional[int] = None,
         scale_factor: Optional[str] = None,
+        fill_subdomain: Optional[bool] = True,
         **kwargs,
     ) -> str:
         """
@@ -230,6 +231,9 @@ class TileProvider(Bunch):
             Scale factor (where supported). For example, you can get double resolution
             (512 x 512) instead of standard one (256 x 256) with ``"@2x"``. If you want
             to keep a placeholder, pass `"{r}"`.
+        fill_subdomain : bool (optional, default True)
+            Fill subdomain placeholder with the first available subdomain. If False, the
+            URL will contain ``{s}`` placeholder for subdomain.
 
         **kwargs
             Other potential attributes updating the :class:`TileProvider`.
@@ -276,14 +280,20 @@ class TileProvider(Bunch):
             )
 
         url = provider.pop("url")
-        subdomains = provider.pop("subdomains", "abc")
+
         if scale_factor:
             r = scale_factor
             provider.pop("r", None)
         else:
             r = provider.pop("r", "")
 
-        return url.format(x=x, y=y, z=z, s=subdomains[0], r=r, **provider)
+        if fill_subdomain:
+            subdomains = provider.pop("subdomains", "abc")
+            s = subdomains[0]
+        else:
+            s = "{s}"
+
+        return url.format(x=x, y=y, z=z, s=s, r=r, **provider)
 
     def requires_token(self) -> bool:
         """


### PR DESCRIPTION
Closes #62

You can now get a URL with `{s}` placeholder intact if that is required.

I have also moved definition of providers in tests to fixtures.