### PR TITLE
TST: test openly accessible tiles and mark broken with `status="broken"` flag

### DIFF
--- a/ci/latest.yaml
+++ b/ci/latest.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python
+  - mercantile
   # tests
   - pytest
   - pytest-cov

--- a/ci/latest.yaml
+++ b/ci/latest.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python
   - mercantile
+  - requests
   # tests
   - pytest
   - pytest-cov

--- a/doc/source/introduction.ipynb
+++ b/doc/source/introduction.ipynb
@@ -169,6 +169,10 @@
     "    \n",
     "```python\n",
     "contextily.add_basemap(ax, source=xyz.OpenWeatherMap.Clouds(apiKey=\"my-private-api-key\"))\n",
+    "```\n",
+    "\n",
+    "```{note}\n",
+    "It may occassionally happen that the `TileProvider` is broken. In such a case, it will have additional attribute `status` with a `\"broken\"` flag. If you think that the `TileProvider` is broken but it is not flagged as such, please [report it](https://github.com/geopandas/xyzservices/issues).\n",
     "```\n"
    ],
    "metadata": {}

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -8,11 +8,24 @@ The compressed JSON is shipped with the package.
 """
 
 import json
+import warnings
+
+# list of providers known to be broken and should be marked as broken in the JSON
+# last update: 8 Aug 2021
+BROKEN_PROVIDERS = [
+    "OpenPtMap",  # service doesn't exist anymore
+    "Hydda.Full",  # down https://github.com/leaflet-extras/leaflet-providers/issues/351
+    "Hydda.Base",
+    "Hydda.RoadsAndLabels",
+    "nlmaps.luchtfoto",  # service phased out
+    "NASAGIBS.ModisTerraSnowCover",  # not sure why but doesn't work
+]
 
 with open("./leaflet-providers-parsed.json", "r") as f:
     leaflet = json.load(f)
     # remove meta data
     leaflet.pop("_meta", None)
+
 
 with open("./xyzservices-providers.json", "r") as f:
     xyz = json.load(f)
@@ -20,6 +33,20 @@ with open("./xyzservices-providers.json", "r") as f:
     xyz.pop("single_provider_name")
     xyz.pop("provider_bunch_name")
 
+
+for provider in BROKEN_PROVIDERS:
+    provider = provider.replace(".", " ").split()
+    try:
+        if len(provider) == 1:
+            leaflet[provider[0]]["status"] = "broken"
+        else:
+            leaflet[provider[0]][provider[1]]["status"] = "broken"
+    except:
+        warnings.warn(
+            f"Attempt to mark {provider} as broken failed. "
+            "The provider does not exist in leaflet-providers JSON.",
+            UserWarning,
+        )
 
 # combine both
 leaflet.update(xyz)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,0 +1,243 @@
+import pytest
+from urllib.error import URLError
+
+import xyzservices.providers as xyz
+from xyzservices import TileProvider, Bunch
+
+
+@pytest.fixture
+def basic_provider():
+    return TileProvider(
+        url="https://myserver.com/tiles/{z}/{x}/{y}.png",
+        attribution="(C) xyzservices",
+        name="my_public_provider",
+    )
+
+
+@pytest.fixture
+def retina_provider():
+    return TileProvider(
+        url="https://myserver.com/tiles/{z}/{x}/{y}{r}.png",
+        attribution="(C) xyzservices",
+        name="my_public_provider2",
+        r="@2x",
+    )
+
+
+@pytest.fixture
+def silent_retina_provider():
+    return TileProvider(
+        url="https://myserver.com/tiles/{z}/{x}/{y}{r}.png",
+        attribution="(C) xyzservices",
+        name="my_public_retina_provider3",
+    )
+
+
+@pytest.fixture
+def private_provider():
+    return TileProvider(
+        url="https://myserver.com/tiles/{z}/{x}/{y}?access_token={accessToken}",
+        attribution="(C) xyzservices",
+        accessToken="<insert your access token here>",
+        name="my_private_provider",
+    )
+
+
+@pytest.fixture
+def html_attr_provider():
+    return TileProvider(
+        url="https://myserver.com/tiles/{z}/{x}/{y}.png",
+        attribution="(C) xyzservices",
+        html_attribution='&copy; <a href="https://xyzservices.readthedocs.io">xyzservices</a>',
+        name="my_public_provider_html",
+    )
+
+
+@pytest.fixture
+def subdomain_provider():
+    return TileProvider(
+        url="https://{s}.myserver.com/tiles/{z}/{x}/{y}.png",
+        attribution="(C) xyzservices",
+        subdomains="abcd",
+        name="my_subdomain_provider",
+    )
+
+
+@pytest.fixture
+def test_bunch(
+    basic_provider,
+    retina_provider,
+    silent_retina_provider,
+    private_provider,
+    html_attr_provider,
+    subdomain_provider,
+):
+    return Bunch(
+        basic_provider=basic_provider,
+        retina_provider=retina_provider,
+        silent_retina_provider=silent_retina_provider,
+        private_provider=private_provider,
+        bunched=Bunch(
+            html_attr_provider=html_attr_provider, subdomain_provider=subdomain_provider
+        ),
+    )
+
+
+def test_expect_name_url_attribution():
+    msg = (
+        "The attributes `name`, `url`, and `attribution` are "
+        "required to initialise a `TileProvider`. Please provide "
+        "values for: "
+    )
+    with pytest.raises(AttributeError, match=msg + "`name`, `url`, `attribution`"):
+        TileProvider({})
+    with pytest.raises(AttributeError, match=msg + "`url`, `attribution`"):
+        TileProvider({"name": "myname"})
+    with pytest.raises(AttributeError, match=msg + "`attribution`"):
+        TileProvider({"url": "my_url", "name": "my_name"})
+    with pytest.raises(AttributeError, match=msg + "`attribution`"):
+        TileProvider(url="my_url", name="my_name")
+
+
+def test_build_url(
+    basic_provider,
+    retina_provider,
+    silent_retina_provider,
+    private_provider,
+    subdomain_provider,
+):
+    expected = "https://myserver.com/tiles/{z}/{x}/{y}.png"
+    assert basic_provider.build_url() == expected
+
+    expected = "https://myserver.com/tiles/3/1/2.png"
+    assert basic_provider.build_url(1, 2, 3) == expected
+    assert basic_provider.build_url(1, 2, 3, scale_factor="@2x") == expected
+    assert silent_retina_provider.build_url(1, 2, 3) == expected
+
+    expected = "https://myserver.com/tiles/3/1/2@2x.png"
+    assert retina_provider.build_url(1, 2, 3) == expected
+    assert silent_retina_provider.build_url(1, 2, 3, scale_factor="@2x") == expected
+
+    expected = "https://myserver.com/tiles/3/1/2@5x.png"
+    assert retina_provider.build_url(1, 2, 3, scale_factor="@5x") == expected
+
+    expected = "https://myserver.com/tiles/{z}/{x}/{y}?access_token=my_token"
+    assert private_provider.build_url(accessToken="my_token") == expected
+
+    with pytest.raises(ValueError, match="Token is required for this provider"):
+        private_provider.build_url()
+
+    expected = "https://{s}.myserver.com/tiles/{z}/{x}/{y}.png"
+    assert subdomain_provider.build_url(fill_subdomain=False)
+
+    expected = "https://a.myserver.com/tiles/{z}/{x}/{y}.png"
+    assert subdomain_provider.build_url()
+
+
+def test_requires_token(private_provider, basic_provider):
+    assert private_provider.requires_token() == True
+    assert basic_provider.requires_token() == False
+
+
+def test_html_repr(basic_provider, retina_provider):
+    provider_strings = [
+        '<div class="xyz-wrap">',
+        '<div class="xyz-header">',
+        '<div class="xyz-obj">xyzservices.TileProvider</div>',
+        '<div class="xyz-name">my_public_provider</div>',
+        '<div class="xyz-details">',
+        '<dl class="xyz-attrs">',
+        "<dt><span>url</span></dt><dd>https://myserver.com/tiles/{z}/{x}/{y}.png</dd>",
+        "<dt><span>attribution</span></dt><dd>(C) xyzservices</dd>",
+    ]
+
+    for html_string in provider_strings:
+        assert html_string in basic_provider._repr_html_()
+
+    bunch = Bunch({"first": basic_provider, "second": retina_provider})
+
+    bunch_strings = [
+        '<div class="xyz-obj">xyzservices.Bunch</div>',
+        '<div class="xyz-name">2 items</div>',
+        '<ul class="xyz-collapsible">',
+        '<li class="xyz-child">',
+        "<span>xyzservices.TileProvider</span>",
+        '<div class="xyz-inside">',
+    ]
+
+    bunch_repr = bunch._repr_html_()
+    for html_string in provider_strings + bunch_strings:
+        assert html_string in bunch_repr
+    assert bunch_repr.count('<li class="xyz-child">') == 2
+    assert bunch_repr.count('<div class="xyz-wrap">') == 3
+    assert bunch_repr.count('<div class="xyz-header">') == 3
+
+
+def test_copy(basic_provider):
+    basic2 = basic_provider.copy()
+    assert isinstance(basic2, TileProvider)
+
+
+def test_callable():
+    # only testing the callable functionality to override a keyword, as we
+    # cannot test the actual providers that need an API key
+    updated_provider = xyz.GeoportailFrance.plan(apikey="mykey")
+    assert isinstance(updated_provider, TileProvider)
+    assert "url" in updated_provider
+    assert updated_provider["apikey"] == "mykey"
+    # check that original provider dict is not modified
+    assert xyz.GeoportailFrance.plan["apikey"] == "choisirgeoportail"
+
+
+def test_html_attribution_fallback(basic_provider, html_attr_provider):
+    # TileProvider.html_attribution falls back to .attribution if the former not present
+    assert basic_provider.html_attribution == basic_provider.attribution
+    assert (
+        html_attr_provider.html_attribution
+        == '&copy; <a href="https://xyzservices.readthedocs.io">xyzservices</a>'
+    )
+
+
+@pytest.mark.xfail(reason="timeout error", raises=URLError)
+def test_from_qms():
+    provider = TileProvider.from_qms("OpenStreetMap Standard aka Mapnik")
+    assert isinstance(provider, TileProvider)
+
+
+@pytest.mark.xfail(reason="timeout error", raises=URLError)
+def test_from_qms_not_found_error():
+    with pytest.raises(ValueError):
+        provider = TileProvider.from_qms("LolWut")
+
+
+def test_flatten(
+    basic_provider, retina_provider, silent_retina_provider, private_provider
+):
+    nested_bunch = Bunch(
+        first_bunch=Bunch(first=basic_provider, second=retina_provider),
+        second_bunch=Bunch(first=silent_retina_provider, second=private_provider),
+    )
+
+    assert len(nested_bunch) == 2
+    assert len(nested_bunch.flatten()) == 4
+
+
+def test_filter(test_bunch):
+    assert len(test_bunch.filter(keyword="private").flatten()) == 1
+    assert len(test_bunch.filter(keyword="public").flatten()) == 4
+    assert len(test_bunch.filter(keyword="{s}").flatten()) == 1
+    assert len(test_bunch.filter(name="retina").flatten()) == 1
+    assert len(test_bunch.filter(requires_token=True).flatten()) == 1
+    assert len(test_bunch.filter(requires_token=False).flatten()) == 5
+    assert len(test_bunch.filter(requires_token=False)) == 4  # check nested structure
+    assert len(test_bunch.filter(keyword="{s}", requires_token=False).flatten()) == 1
+    assert len(test_bunch.filter(name="nonsense").flatten()) == 0
+
+    def custom(provider):
+        if hasattr(provider, "subdomains") and provider.subdomains == "abcd":
+            return True
+        if hasattr(provider, "r"):
+            return True
+        return False
+
+    assert len(test_bunch.filter(function=custom).flatten()) == 2

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,86 +1,9 @@
 import pytest
-from urllib.error import URLError
-
 import xyzservices.providers as xyz
-from xyzservices import TileProvider, Bunch
+import requests
+import mercantile
 
-
-@pytest.fixture
-def basic_provider():
-    return TileProvider(
-        url="https://myserver.com/tiles/{z}/{x}/{y}.png",
-        attribution="(C) xyzservices",
-        name="my_public_provider",
-    )
-
-
-@pytest.fixture
-def retina_provider():
-    return TileProvider(
-        url="https://myserver.com/tiles/{z}/{x}/{y}{r}.png",
-        attribution="(C) xyzservices",
-        name="my_public_provider2",
-        r="@2x",
-    )
-
-
-@pytest.fixture
-def silent_retina_provider():
-    return TileProvider(
-        url="https://myserver.com/tiles/{z}/{x}/{y}{r}.png",
-        attribution="(C) xyzservices",
-        name="my_public_retina_provider3",
-    )
-
-
-@pytest.fixture
-def private_provider():
-    return TileProvider(
-        url="https://myserver.com/tiles/{z}/{x}/{y}?access_token={accessToken}",
-        attribution="(C) xyzservices",
-        accessToken="<insert your access token here>",
-        name="my_private_provider",
-    )
-
-
-@pytest.fixture
-def html_attr_provider():
-    return TileProvider(
-        url="https://myserver.com/tiles/{z}/{x}/{y}.png",
-        attribution="(C) xyzservices",
-        html_attribution='&copy; <a href="https://xyzservices.readthedocs.io">xyzservices</a>',
-        name="my_public_provider_html",
-    )
-
-
-@pytest.fixture
-def subdomain_provider():
-    return TileProvider(
-        url="https://{s}.myserver.com/tiles/{z}/{x}/{y}.png",
-        attribution="(C) xyzservices",
-        subdomains="abcd",
-        name="my_subdomain_provider",
-    )
-
-
-@pytest.fixture
-def test_bunch(
-    basic_provider,
-    retina_provider,
-    silent_retina_provider,
-    private_provider,
-    html_attr_provider,
-    subdomain_provider,
-):
-    return Bunch(
-        basic_provider=basic_provider,
-        retina_provider=retina_provider,
-        silent_retina_provider=silent_retina_provider,
-        private_provider=private_provider,
-        bunched=Bunch(
-            html_attr_provider=html_attr_provider, subdomain_provider=subdomain_provider
-        ),
-    )
+flat_free = xyz.filter(requires_token=False).flatten()
 
 
 def check_provider(provider):
@@ -91,173 +14,55 @@ def check_provider(provider):
         assert option in provider.url
 
 
-@pytest.mark.parametrize("provider_name", xyz.keys())
+def get_tile(provider):
+    bounds = provider.get("bounds", [[-180, -90], [180, 90]])
+    lat = (bounds[0][0] + bounds[1][0]) / 2
+    lon = (bounds[0][1] + bounds[1][1]) / 2
+    zoom = (provider.get("min_zoom", 0) + provider.get("max_zoom", 20)) // 2
+    tile = mercantile.tile(lon, lat, zoom)
+    z = tile.z
+    x = tile.x
+    y = tile.y
+    return (z, x, y)
+
+
+def get_response(url):
+    s = requests.Session()
+    a = requests.adapters.HTTPAdapter(max_retries=3)
+    s.mount("http://", a)
+    s.mount("https://", a)
+    r = s.get(url)
+    return r.status_code
+
+
+@pytest.mark.parametrize("provider_name", xyz.flatten())
 def test_minimal_provider_metadata(provider_name):
-    provider = xyz[provider_name]
-
-    if "url" in provider.keys():
-        check_provider(provider)
-
-    else:
-        for variant in xyz[provider_name]:
-            check_provider(xyz[provider_name][variant])
+    provider = xyz.flatten()[provider_name]
+    check_provider(provider)
 
 
-def test_expect_name_url_attribution():
-    msg = (
-        "The attributes `name`, `url`, and `attribution` are "
-        "required to initialise a `TileProvider`. Please provide "
-        "values for: "
-    )
-    with pytest.raises(AttributeError, match=msg + "`name`, `url`, `attribution`"):
-        TileProvider({})
-    with pytest.raises(AttributeError, match=msg + "`url`, `attribution`"):
-        TileProvider({"name": "myname"})
-    with pytest.raises(AttributeError, match=msg + "`attribution`"):
-        TileProvider({"url": "my_url", "name": "my_name"})
-    with pytest.raises(AttributeError, match=msg + "`attribution`"):
-        TileProvider(url="my_url", name="my_name")
+@pytest.mark.parametrize("name", flat_free)
+def test_free_providers(name):
+    provider = flat_free[name]
+    z, x, y = get_tile(provider)
 
+    try:
+        r = get_response(provider.build_url(z=z, x=x, y=y))
+        assert r == requests.codes.ok
+    except AssertionError as e:
+        if r == 403:
+            pytest.xfail("Provider not available due to API restrictions (Error 403).")
 
-def test_build_url(
-    basic_provider,
-    retina_provider,
-    silent_retina_provider,
-    private_provider,
-    subdomain_provider,
-):
-    expected = "https://myserver.com/tiles/{z}/{x}/{y}.png"
-    assert basic_provider.build_url() == expected
-
-    expected = "https://myserver.com/tiles/3/1/2.png"
-    assert basic_provider.build_url(1, 2, 3) == expected
-    assert basic_provider.build_url(1, 2, 3, scale_factor="@2x") == expected
-    assert silent_retina_provider.build_url(1, 2, 3) == expected
-
-    expected = "https://myserver.com/tiles/3/1/2@2x.png"
-    assert retina_provider.build_url(1, 2, 3) == expected
-    assert silent_retina_provider.build_url(1, 2, 3, scale_factor="@2x") == expected
-
-    expected = "https://myserver.com/tiles/3/1/2@5x.png"
-    assert retina_provider.build_url(1, 2, 3, scale_factor="@5x") == expected
-
-    expected = "https://myserver.com/tiles/{z}/{x}/{y}?access_token=my_token"
-    assert private_provider.build_url(accessToken="my_token") == expected
-
-    with pytest.raises(ValueError, match="Token is required for this provider"):
-        private_provider.build_url()
-
-    expected = "https://{s}.myserver.com/tiles/{z}/{x}/{y}.png"
-    assert subdomain_provider.build_url(fill_subdomain=False)
-
-    expected = "https://a.myserver.com/tiles/{z}/{x}/{y}.png"
-    assert subdomain_provider.build_url()
-
-
-def test_requires_token(private_provider, basic_provider):
-    assert private_provider.requires_token() == True
-    assert basic_provider.requires_token() == False
-
-
-def test_html_repr(basic_provider, retina_provider):
-    provider_strings = [
-        '<div class="xyz-wrap">',
-        '<div class="xyz-header">',
-        '<div class="xyz-obj">xyzservices.TileProvider</div>',
-        '<div class="xyz-name">my_public_provider</div>',
-        '<div class="xyz-details">',
-        '<dl class="xyz-attrs">',
-        "<dt><span>url</span></dt><dd>https://myserver.com/tiles/{z}/{x}/{y}.png</dd>",
-        "<dt><span>attribution</span></dt><dd>(C) xyzservices</dd>",
-    ]
-
-    for html_string in provider_strings:
-        assert html_string in basic_provider._repr_html_()
-
-    bunch = Bunch({"first": basic_provider, "second": retina_provider})
-
-    bunch_strings = [
-        '<div class="xyz-obj">xyzservices.Bunch</div>',
-        '<div class="xyz-name">2 items</div>',
-        '<ul class="xyz-collapsible">',
-        '<li class="xyz-child">',
-        "<span>xyzservices.TileProvider</span>",
-        '<div class="xyz-inside">',
-    ]
-
-    bunch_repr = bunch._repr_html_()
-    for html_string in provider_strings + bunch_strings:
-        assert html_string in bunch_repr
-    assert bunch_repr.count('<li class="xyz-child">') == 2
-    assert bunch_repr.count('<div class="xyz-wrap">') == 3
-    assert bunch_repr.count('<div class="xyz-header">') == 3
-
-
-def test_copy(basic_provider):
-    basic2 = basic_provider.copy()
-    assert isinstance(basic2, TileProvider)
-
-
-def test_callable():
-    # only testing the callable functionality to override a keyword, as we
-    # cannot test the actual providers that need an API key
-    updated_provider = xyz.GeoportailFrance.plan(apikey="mykey")
-    assert isinstance(updated_provider, TileProvider)
-    assert "url" in updated_provider
-    assert updated_provider["apikey"] == "mykey"
-    # check that original provider dict is not modified
-    assert xyz.GeoportailFrance.plan["apikey"] == "choisirgeoportail"
-
-
-def test_html_attribution_fallback(basic_provider, html_attr_provider):
-    # TileProvider.html_attribution falls back to .attribution if the former not present
-    assert basic_provider.html_attribution == basic_provider.attribution
-    assert (
-        html_attr_provider.html_attribution
-        == '&copy; <a href="https://xyzservices.readthedocs.io">xyzservices</a>'
-    )
-
-
-@pytest.mark.xfail(reason="timeout error", raises=URLError)
-def test_from_qms():
-    provider = TileProvider.from_qms("OpenStreetMap Standard aka Mapnik")
-    assert isinstance(provider, TileProvider)
-
-
-@pytest.mark.xfail(reason="timeout error", raises=URLError)
-def test_from_qms_not_found_error():
-    with pytest.raises(ValueError):
-        provider = TileProvider.from_qms("LolWut")
-
-
-def test_flatten(
-    basic_provider, retina_provider, silent_retina_provider, private_provider
-):
-    nested_bunch = Bunch(
-        first_bunch=Bunch(first=basic_provider, second=retina_provider),
-        second_bunch=Bunch(first=silent_retina_provider, second=private_provider),
-    )
-
-    assert len(nested_bunch) == 2
-    assert len(nested_bunch.flatten()) == 4
-
-
-def test_filter(test_bunch):
-    assert len(test_bunch.filter(keyword="private").flatten()) == 1
-    assert len(test_bunch.filter(keyword="public").flatten()) == 4
-    assert len(test_bunch.filter(keyword="{s}").flatten()) == 1
-    assert len(test_bunch.filter(name="retina").flatten()) == 1
-    assert len(test_bunch.filter(requires_token=True).flatten()) == 1
-    assert len(test_bunch.filter(requires_token=False).flatten()) == 5
-    assert len(test_bunch.filter(requires_token=False)) == 4  # check nested structure
-    assert len(test_bunch.filter(keyword="{s}", requires_token=False).flatten()) == 1
-    assert len(test_bunch.filter(name="nonsense").flatten()) == 0
-
-    def custom(provider):
-        if hasattr(provider, "subdomains") and provider.subdomains == "abcd":
-            return True
-        if hasattr(provider, "r"):
-            return True
-        return False
-
-    assert len(test_bunch.filter(function=custom).flatten()) == 2
+        # check another tiles
+        elif r in [404, 502]:
+            # in some cases, the computed tile is not availble. trying known tiles.
+            options = [(12, 2154, 1363), (6, 13, 21), (16, 33149, 22973)]
+            results = []
+            for o in options:
+                z, x, y = o
+                r = get_response(provider.build_url(z=z, x=x, y=y))
+                results.append(r)
+            if not any([x == requests.codes.ok for x in results]):
+                raise ValueError(f"Response code: {r}")
+        else:
+            raise ValueError(f"Response code: {r}")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -44,6 +44,10 @@ def test_minimal_provider_metadata(provider_name):
 @pytest.mark.parametrize("name", flat_free)
 def test_free_providers(name):
     provider = flat_free[name]
+
+    if provider.get("status"):
+        pytest.xfail("Provider is known to be broken.")
+
     z, x, y = get_tile(provider)
 
     try:
@@ -52,6 +56,9 @@ def test_free_providers(name):
     except AssertionError as e:
         if r == 403:
             pytest.xfail("Provider not available due to API restrictions (Error 403).")
+
+        elif r == 503:
+            pytest.xfail("Service temporarily unavailable (Error 503).")
 
         # check another tiles
         elif r in [404, 502]:

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -74,7 +74,8 @@
         "max_zoom": 17,
         "html_attribution": "Map data: &copy; <a href=\"http://www.openptmap.org\">OpenPtMap</a> contributors",
         "attribution": "Map data: (C) OpenPtMap contributors",
-        "name": "OpenPtMap"
+        "name": "OpenPtMap",
+        "status": "broken"
     },
     "OpenTopoMap": {
         "url": "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
@@ -231,7 +232,8 @@
             "variant": "full",
             "html_attribution": "Tiles courtesy of <a href=\"http://openstreetmap.se/\" target=\"_blank\">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "Tiles courtesy of OpenStreetMap Sweden -- Map data (C) OpenStreetMap contributors",
-            "name": "Hydda.Full"
+            "name": "Hydda.Full",
+            "status": "broken"
         },
         "Base": {
             "url": "https://{s}.tile.openstreetmap.se/hydda/{variant}/{z}/{x}/{y}.png",
@@ -239,7 +241,8 @@
             "variant": "base",
             "html_attribution": "Tiles courtesy of <a href=\"http://openstreetmap.se/\" target=\"_blank\">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "Tiles courtesy of OpenStreetMap Sweden -- Map data (C) OpenStreetMap contributors",
-            "name": "Hydda.Base"
+            "name": "Hydda.Base",
+            "status": "broken"
         },
         "RoadsAndLabels": {
             "url": "https://{s}.tile.openstreetmap.se/hydda/{variant}/{z}/{x}/{y}.png",
@@ -247,7 +250,8 @@
             "variant": "roads_and_labels",
             "html_attribution": "Tiles courtesy of <a href=\"http://openstreetmap.se/\" target=\"_blank\">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "Tiles courtesy of OpenStreetMap Sweden -- Map data (C) OpenStreetMap contributors",
-            "name": "Hydda.RoadsAndLabels"
+            "name": "Hydda.RoadsAndLabels",
+            "status": "broken"
         }
     },
     "Jawg": {
@@ -2195,7 +2199,8 @@
             ],
             "html_attribution": "Kaartgegevens &copy; <a href=\"https://www.kadaster.nl\">Kadaster</a>",
             "attribution": "Kaartgegevens (C) Kadaster",
-            "name": "nlmaps.luchtfoto"
+            "name": "nlmaps.luchtfoto",
+            "status": "broken"
         }
     },
     "NASAGIBS": {
@@ -2309,7 +2314,8 @@
             "tilematrixset": "GoogleMapsCompatible_Level",
             "variant": "MODIS_Terra_Snow_Cover",
             "opacity": 0.75,
-            "name": "NASAGIBS.ModisTerraSnowCover"
+            "name": "NASAGIBS.ModisTerraSnowCover",
+            "status": "broken"
         },
         "ModisTerraAOD": {
             "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",


### PR DESCRIPTION
Splitting test suite into 2 files and adding tests that check all providers that do not require any API key.

I will also add a machinery marking broken sources coming from leaflet-providers and removing them from the compressed json. Just want to run CI before that to show how it behaves with broken tiles.

Some (Stadia) do not require API key according to our metadata but the domain needs to be whitelisted to make them work. Those give 403 error and are xfailed.