### PR TITLE
DOC: document registrations, add disclaimers

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -67,6 +67,10 @@ True
 False
 ```
 
+```{important}
+You should always check the license and terms and conditions of XYZ tiles you want to use. Not all of them can be used in all circumstances.
+```
+
 ### Providers JSON
 
 After the installation, you will find the JSON used as a database of providers in
@@ -77,6 +81,11 @@ After the installation, you will find the JSON used as a database of providers i
 `xyzservices` is developed by a community of enthusiastic volunteers and lives under
 [`geopandas`](https://github.com/geopandas) GitHub organization. You can see a full list
 of contributors [here](https://github.com/geopandas/xyzservices/graphs/contributors).
+
+The main group of providers is retrieved from the [`leaflet-providers`
+project](https://github.com/leaflet-extras/leaflet-providers) that contains both openly
+accessible providers as well as those requiring registration. All of them are considered
+[free](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md#what-do-we-mean-by-free).
 
 If you would like to contribute to the project, have a look at the list of
 [open issues](https://github.com/geopandas/contextily/issues), particularly those labeled as
@@ -94,6 +103,7 @@ caption: Documentation
 hidden: true
 ---
 introduction
+registration
 api
 contributing
 changelog

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -95,6 +95,10 @@ If you would like to contribute to the project, have a look at the list of
 
 BSD 3-Clause License
 
+Resources coming from the [`leaflet-providers`
+project](https://github.com/leaflet-extras/leaflet-providers) are licensed under BSD
+2-Clause License (© 2013 Leaflet Providers)
+
 
 ```{toctree}
 ---

--- a/doc/source/introduction.ipynb
+++ b/doc/source/introduction.ipynb
@@ -104,7 +104,11 @@
   {
    "cell_type": "markdown",
    "source": [
-    "The providers definitions that are shipped with `xyzservices` in the `xyzservices.providers` submodule, are coming from the [`leaflet-providers`](https://github.com/leaflet-extras/leaflet-providers) package, an extension to javascript mapping library Leaflet that contains configurations for various free tile providers. Thus, all providers that are listed on their preview (http://leaflet-extras.github.io/leaflet-providers/preview/) should also be available in `xyzservices`. On top of that, `xyzservices` can have a few more as a bonus."
+    "The providers definitions that are shipped with `xyzservices` in the `xyzservices.providers` submodule, are coming from the [`leaflet-providers`](https://github.com/leaflet-extras/leaflet-providers) package, an extension to javascript mapping library Leaflet that contains configurations for various free tile providers. Thus, all providers that are listed on their preview [http://leaflet-extras.github.io/leaflet-providers/preview/](http://leaflet-extras.github.io/leaflet-providers/preview/) should also be available in `xyzservices`. On top of that, `xyzservices` can have a few more as a bonus.\n",
+    "\n",
+    "```{important}\n",
+    "You should always check the license and terms and conditions of XYZ tiles you want to use. Not all of them can be used in all circumstances.\n",
+    "```"
    ],
    "metadata": {}
   },
@@ -502,7 +506,7 @@
    "cell_type": "markdown",
    "source": [
     "```{important}\n",
-    "You should always check the license of XYZ tiles you want to use. Not all of them can be used in all circumstances.\n",
+    "You should always check the license and terms and conditions of XYZ tiles you want to use. Not all of them can be used in all circumstances and not all Quick Map Services can be considered free even though they may work.\n",
     "```"
    ],
    "metadata": {}

--- a/doc/source/registration.md
+++ b/doc/source/registration.md
@@ -1,0 +1,88 @@
+# Providers requiring registration
+
+The main group of providers is retrieved from the [`leaflet-providers` project](https://github.com/leaflet-extras/leaflet-providers) that contains both openly accessible providers as well as those requiring registration. All of them are considered [free](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md#what-do-we-mean-by-free).
+
+Below is (potentially incomplete) list of providers requiring registration.
+
+```{note}
+This page is largely taken directly from the [`leaflet-providers` project](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md).
+```
+
+## HERE and HEREv3 (formerly Nokia).
+
+In order to use HEREv3 layers, you must [register](http://developer.here.com/). Once registered, you can create an `apiKey` which you have to pass to `TileProvider`:
+
+```py
+# Overriding the attribute will alter the existing object
+xyz.HEREv3.terrainDay["apiKey"] = "my-private-api-key"
+
+# Calling the object will return a copy
+xyz.HEREv3.terrainDay(apiKey="my-private-api-key")
+```
+
+You can still pass `app_id` and `app_code` in legacy projects:
+
+```py
+xyz.HEREv3.terrainDay(app_id="my-private-app-id", app_code="my-app-code")
+```
+
+## Jawg Maps
+
+In order to use Jawg Maps, you must [register](https://www.jawg.io/lab). Once registered, your access token will be located [here](https://www.jawg.io/lab/access-tokens) and you will access to all Jawg default maps (variants) and your own customized maps :
+
+```py
+xyz.Jawg.Streets(
+    accessToken="<insert access token here>",
+    variant="<insert map id here or blank for default variant>"
+)
+```
+
+## Mapbox
+
+In order to use Mapbox maps, you must [register](https://tiles.mapbox.com/signup). You can get map_ID (e.g. `"mapbox/satellite-v9"`) and `ACCESS_TOKEN` from [Mapbox projects](https://www.mapbox.com/projects):
+
+```py
+xyz.MapBox(id="<insert map_ID here>", accessToken="my-private-ACCESS_TOKEN")
+```
+
+The currently-valid Mapbox map styles, to use for map_IDs, [are listed in the Mapbox documentation](https://docs.mapbox.com/api/maps/#mapbox-styles) - only the final part of each is required, e.g. `"mapbox/light-v10"`.
+
+## MapTiler Cloud
+
+In order to use MapTiler maps, you must [register](https://cloud.maptiler.com/). Once registered, get your API key from Account/Keys, which you have to pass to `TileProvider`:
+```py
+xyz.MapTiler.Streets(key="<insert key here>")
+```
+
+## Thunderforest
+
+In order to use Thunderforest maps, you must [register](https://thunderforest.com/pricing/). Once registered, you have an `api_key` which you have to pass to `TileProvider`:
+```py
+xyz.Thunderforest.Landscape(apikey="<insert api_key here>")
+```
+
+## Esri/ArcGIS
+
+In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of service](https://developers.arcgis.com/en/terms/). No special syntax is required.
+
+## TomTom
+
+In order to use TomTom layers, you must [register](https://developer.tomtom.com/user/register). Once registered, you can create an `apikey` which you have to pass to `TileProvider`:
+
+```py
+xyz.TomTom(apikey="<insert api_key here>")
+```
+
+## Geoportail France
+
+In order to use Geoportail France resources, you need to obtain an [api key](http://professionnels.ign.fr/ign/contrats/) that allows you to access the [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator) you need. Pass this api key and the ID of the resource to display to `TileProvider`:
+
+```py
+xyz.GeoportailFrance.plan(apikey="<insert api_key here>")
+```
+
+Please note that a public api key (`choisirgeoportail`) is used by default and comes with no guarantee.
+
+## Stadia Maps
+
+In order to use Stadia maps, you must [register](https://client.stadiamaps.com/signup/). Once registered, you can whitelist your domain within your account settings.

--- a/doc/source/registration.md
+++ b/doc/source/registration.md
@@ -2,7 +2,7 @@
 
 The main group of providers is retrieved from the [`leaflet-providers` project](https://github.com/leaflet-extras/leaflet-providers) that contains both openly accessible providers as well as those requiring registration. All of them are considered [free](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md#what-do-we-mean-by-free).
 
-Below is (potentially incomplete) list of providers requiring registration.
+Below is the (potentially incomplete) list of providers requiring registration.
 
 ```{note}
 This page is largely taken directly from the [`leaflet-providers` project](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md).
@@ -10,7 +10,7 @@ This page is largely taken directly from the [`leaflet-providers` project](https
 
 ## HERE and HEREv3 (formerly Nokia).
 
-In order to use HEREv3 layers, you must [register](http://developer.here.com/). Once registered, you can create an `apiKey` which you have to pass to `TileProvider`:
+In order to use HEREv3 layers, you must [register](http://developer.here.com/). Once registered, you can create an `apiKey` which you have to pass to the `TileProvider`:
 
 ```py
 # Overriding the attribute will alter the existing object
@@ -28,7 +28,7 @@ xyz.HEREv3.terrainDay(app_id="my-private-app-id", app_code="my-app-code")
 
 ## Jawg Maps
 
-In order to use Jawg Maps, you must [register](https://www.jawg.io/lab). Once registered, your access token will be located [here](https://www.jawg.io/lab/access-tokens) and you will access to all Jawg default maps (variants) and your own customized maps :
+In order to use Jawg Maps, you must [register](https://www.jawg.io/lab). Once registered, your access token will be located [here](https://www.jawg.io/lab/access-tokens) and you will access to all Jawg default maps (variants) and your own customized maps:
 
 ```py
 xyz.Jawg.Streets(
@@ -49,14 +49,14 @@ The currently-valid Mapbox map styles, to use for map_IDs, [are listed in the Ma
 
 ## MapTiler Cloud
 
-In order to use MapTiler maps, you must [register](https://cloud.maptiler.com/). Once registered, get your API key from Account/Keys, which you have to pass to `TileProvider`:
+In order to use MapTiler maps, you must [register](https://cloud.maptiler.com/). Once registered, get your API key from Account/Keys, which you have to pass to the `TileProvider`:
 ```py
 xyz.MapTiler.Streets(key="<insert key here>")
 ```
 
 ## Thunderforest
 
-In order to use Thunderforest maps, you must [register](https://thunderforest.com/pricing/). Once registered, you have an `api_key` which you have to pass to `TileProvider`:
+In order to use Thunderforest maps, you must [register](https://thunderforest.com/pricing/). Once registered, you have an `api_key` which you have to pass to the `TileProvider`:
 ```py
 xyz.Thunderforest.Landscape(apikey="<insert api_key here>")
 ```
@@ -67,7 +67,7 @@ In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/e
 
 ## TomTom
 
-In order to use TomTom layers, you must [register](https://developer.tomtom.com/user/register). Once registered, you can create an `apikey` which you have to pass to `TileProvider`:
+In order to use TomTom layers, you must [register](https://developer.tomtom.com/user/register). Once registered, you can create an `apikey` which you have to pass to the `TileProvider`:
 
 ```py
 xyz.TomTom(apikey="<insert api_key here>")
@@ -75,7 +75,7 @@ xyz.TomTom(apikey="<insert api_key here>")
 
 ## Geoportail France
 
-In order to use Geoportail France resources, you need to obtain an [api key](http://professionnels.ign.fr/ign/contrats/) that allows you to access the [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator) you need. Pass this api key and the ID of the resource to display to `TileProvider`:
+In order to use Geoportail France resources, you need to obtain an [api key](http://professionnels.ign.fr/ign/contrats/) that allows you to access the [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator) you need. Pass this api key to the `TileProvider`:
 
 ```py
 xyz.GeoportailFrance.plan(apikey="<insert api_key here>")

--- a/doc/source/registration.md
+++ b/doc/source/registration.md
@@ -1,6 +1,9 @@
 # Providers requiring registration
 
-The main group of providers is retrieved from the [`leaflet-providers` project](https://github.com/leaflet-extras/leaflet-providers) that contains both openly accessible providers as well as those requiring registration. All of them are considered [free](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md#what-do-we-mean-by-free).
+The main group of providers is retrieved from the [`leaflet-providers`
+project](https://github.com/leaflet-extras/leaflet-providers) that contains both openly
+accessible providers as well as those requiring registration. All of them are considered
+[free](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md#what-do-we-mean-by-free).
 
 Below is the (potentially incomplete) list of providers requiring registration.
 
@@ -8,9 +11,31 @@ Below is the (potentially incomplete) list of providers requiring registration.
 This page is largely taken directly from the [`leaflet-providers` project](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md).
 ```
 
+## Esri/ArcGIS
+
+In order to use ArcGIS maps, you must
+[register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of
+service](https://developers.arcgis.com/en/terms/). No special syntax is required.
+
+## Geoportail France
+
+In order to use Geoportail France resources, you need to obtain an [api
+key](http://professionnels.ign.fr/ign/contrats/) that allows you to access the
+[resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator)
+you need. Pass this api key to the `TileProvider`:
+
+```py
+xyz.GeoportailFrance.plan(apikey="<insert api_key here>")
+```
+
+Please note that a public api key (`choisirgeoportail`) is used by default and comes
+with no guarantee.
+
+
 ## HERE and HEREv3 (formerly Nokia).
 
-In order to use HEREv3 layers, you must [register](http://developer.here.com/). Once registered, you can create an `apiKey` which you have to pass to the `TileProvider`:
+In order to use HEREv3 layers, you must [register](http://developer.here.com/). Once
+registered, you can create an `apiKey` which you have to pass to the `TileProvider`:
 
 ```py
 # Overriding the attribute will alter the existing object
@@ -28,7 +53,10 @@ xyz.HEREv3.terrainDay(app_id="my-private-app-id", app_code="my-app-code")
 
 ## Jawg Maps
 
-In order to use Jawg Maps, you must [register](https://www.jawg.io/lab). Once registered, your access token will be located [here](https://www.jawg.io/lab/access-tokens) and you will access to all Jawg default maps (variants) and your own customized maps:
+In order to use Jawg Maps, you must [register](https://www.jawg.io/lab). Once
+registered, your access token will be located
+[here](https://www.jawg.io/lab/access-tokens) and you will access to all Jawg default
+maps (variants) and your own customized maps:
 
 ```py
 xyz.Jawg.Streets(
@@ -39,50 +67,47 @@ xyz.Jawg.Streets(
 
 ## Mapbox
 
-In order to use Mapbox maps, you must [register](https://tiles.mapbox.com/signup). You can get map_ID (e.g. `"mapbox/satellite-v9"`) and `ACCESS_TOKEN` from [Mapbox projects](https://www.mapbox.com/projects):
+In order to use Mapbox maps, you must [register](https://tiles.mapbox.com/signup). You
+can get map_ID (e.g. `"mapbox/satellite-v9"`) and `ACCESS_TOKEN` from [Mapbox
+projects](https://www.mapbox.com/projects):
 
 ```py
 xyz.MapBox(id="<insert map_ID here>", accessToken="my-private-ACCESS_TOKEN")
 ```
 
-The currently-valid Mapbox map styles, to use for map_IDs, [are listed in the Mapbox documentation](https://docs.mapbox.com/api/maps/#mapbox-styles) - only the final part of each is required, e.g. `"mapbox/light-v10"`.
+The currently-valid Mapbox map styles, to use for map_IDs, [are listed in the Mapbox
+documentation](https://docs.mapbox.com/api/maps/#mapbox-styles) - only the final part of
+each is required, e.g. `"mapbox/light-v10"`.
 
 ## MapTiler Cloud
 
-In order to use MapTiler maps, you must [register](https://cloud.maptiler.com/). Once registered, get your API key from Account/Keys, which you have to pass to the `TileProvider`:
+In order to use MapTiler maps, you must [register](https://cloud.maptiler.com/). Once
+registered, get your API key from Account/Keys, which you have to pass to the
+`TileProvider`:
 ```py
 xyz.MapTiler.Streets(key="<insert key here>")
 ```
 
 ## Thunderforest
 
-In order to use Thunderforest maps, you must [register](https://thunderforest.com/pricing/). Once registered, you have an `api_key` which you have to pass to the `TileProvider`:
+In order to use Thunderforest maps, you must
+[register](https://thunderforest.com/pricing/). Once registered, you have an `api_key`
+which you have to pass to the `TileProvider`:
 ```py
 xyz.Thunderforest.Landscape(apikey="<insert api_key here>")
 ```
 
-## Esri/ArcGIS
-
-In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of service](https://developers.arcgis.com/en/terms/). No special syntax is required.
-
 ## TomTom
 
-In order to use TomTom layers, you must [register](https://developer.tomtom.com/user/register). Once registered, you can create an `apikey` which you have to pass to the `TileProvider`:
+In order to use TomTom layers, you must
+[register](https://developer.tomtom.com/user/register). Once registered, you can create
+an `apikey` which you have to pass to the `TileProvider`:
 
 ```py
 xyz.TomTom(apikey="<insert api_key here>")
 ```
 
-## Geoportail France
-
-In order to use Geoportail France resources, you need to obtain an [api key](http://professionnels.ign.fr/ign/contrats/) that allows you to access the [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator) you need. Pass this api key to the `TileProvider`:
-
-```py
-xyz.GeoportailFrance.plan(apikey="<insert api_key here>")
-```
-
-Please note that a public api key (`choisirgeoportail`) is used by default and comes with no guarantee.
-
 ## Stadia Maps
 
-In order to use Stadia maps, you must [register](https://client.stadiamaps.com/signup/). Once registered, you can whitelist your domain within your account settings.
+In order to use Stadia maps, you must [register](https://client.stadiamaps.com/signup/).
+Once registered, you can whitelist your domain within your account settings.


### PR DESCRIPTION
Using the [`leaflet-providers` project description](https://github.com/leaflet-extras/leaflet-providers/blob/master/README.md) of providers requiring API token/registration + minor edits of the docs.