### PR TITLE
Ipyleaflet providers and fix for compress providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Next release
+------------
+
+Providers:
+
+- Added ``OpenStreetMap.BlackAndWhite`` (#83)
+- Added ``Gaode`` tiles (``Normal`` and ``Satellite``) (#83)
+- Expanded ``NASAGIBS`` tiles with ``ModisTerraBands721CR``, ``ModisAquaTrueColorCR``, ``ModisAquaBands721CR`` and ``ViirsTrueColorCR`` (#83)
+- Added metadata to ``Strava`` maps (currently down) (#83)
+
+
 xyzservices 2021.08.0 (August 8, 2021)
 --------------------------------------
 

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -10,6 +10,8 @@ The compressed JSON is shipped with the package.
 import json
 import warnings
 
+from xyzservices import Bunch
+
 # list of providers known to be broken and should be marked as broken in the JSON
 # last update: 8 Aug 2021
 BROKEN_PROVIDERS = [
@@ -52,9 +54,7 @@ for provider in BROKEN_PROVIDERS:
 
 for key, val in xyz.items():
     if key in leaflet:
-        if any(
-            isinstance(i, dict) for i in leaflet[key].values()
-        ):  # for related group of bunch
+        if isinstance(val, Bunch):  # for related group of bunch
             leaflet[key].update(xyz[key])
         else:
             leaflet[key] = xyz[key]

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -10,8 +10,6 @@ The compressed JSON is shipped with the package.
 import json
 import warnings
 
-from xyzservices import Bunch
-
 # list of providers known to be broken and should be marked as broken in the JSON
 # last update: 8 Aug 2021
 BROKEN_PROVIDERS = [
@@ -31,10 +29,6 @@ with open("./leaflet-providers-parsed.json", "r") as f:
 
 with open("./xyzservices-providers.json", "r") as f:
     xyz = json.load(f)
-    # remove templates
-    xyz.pop("single_provider_name")
-    xyz.pop("provider_bunch_name")
-
 
 for provider in BROKEN_PROVIDERS:
     provider = provider.replace(".", " ").split()
@@ -54,7 +48,9 @@ for provider in BROKEN_PROVIDERS:
 
 for key, val in xyz.items():
     if key in leaflet:
-        if isinstance(val, Bunch):  # for related group of bunch
+        if any(
+             isinstance(i, dict) for i in leaflet[key].values()
+         ):   # for related group of bunch
             leaflet[key].update(xyz[key])
         else:
             leaflet[key] = xyz[key]

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -49,7 +49,18 @@ for provider in BROKEN_PROVIDERS:
         )
 
 # combine both
-leaflet.update(xyz)
+
+for key, val in xyz.items():
+    if key in leaflet:
+        if any(
+            isinstance(i, dict) for i in leaflet[key].values()
+        ):  # for related group of bunch
+            leaflet[key].update(xyz[key])
+        else:
+            leaflet[key] = xyz[key]
+    else:
+        leaflet[key] = xyz[key]
+
 
 with open("../xyzservices/data/providers.json", "w") as f:
     json.dump(leaflet, f, indent=4)

--- a/provider_sources/xyzservices-providers.json
+++ b/provider_sources/xyzservices-providers.json
@@ -1,26 +1,103 @@
 {
-    "single_provider_name": {
-        "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "max_zoom": 19,
-        "attribution": "(C) OpenStreetMap contributors",
-        "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-        "name": "OpenStreetMap.Mapnik"
+    "OpenStreetMap": {
+        "BlackAndWhite": {
+            "url": "http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png",
+            "max_zoom": 18,
+            "attribution": "(C) OpenStreetMap contributors",
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "name": "OpenStreetMap.BlackAndWhite"
+        }
     },
-    "provider_bunch_name": {
-        "first_provider_name": {
-            "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-            "max_zoom": 19,
-            "attribution": "(C) OpenStreetMap contributors",
-            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "name": "OpenStreetMap.Mapnik"
+    "NASAGIBS": {
+        "ModisTerraBands721CR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+            "max_zoom": 9,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "name": "NASAGIBS.ModisTerraBands721CR",
+            "time": ""
         },
-        "second_provider_name": {
-            "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?access-token={accessToken}",
+        "ModisAquaTrueColorCR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+            "max_zoom": 9,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "name": "NASAGIBS.ModisAquaTrueColorCR",
+            "time": ""
+        },
+        "ModisAquaBands721CR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+            "max_zoom": 9,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "name": "NASAGIBS.ModisAquaBands721CR",
+            "time": ""
+        },
+        "ViirsTrueColorCR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+            "max_zoom": 9,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "name": "NASAGIBS.ViirsTrueColorCR",
+            "time": ""
+        }
+    },
+    "Gaode": {
+        "Normal": {
+            "url": "http://webrd01.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=7&x={x}&y={y}&z={z}",
             "max_zoom": 19,
+            "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "html_attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "name": "Gaode.Normal"
+        },
+        "Satellite": {
+            "url": "http://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}",
+            "max_zoom": 19,
+            "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "html_attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "name": "Gaode.Satellite"
+        }
+    },
+    "Strava": {
+        "All": {
+            "url": "https://heatmap-external-a.strava.com//tiles/all/hot/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.All",
+            "status": "broken"
+        },
+        "Ride": {
+            "url": "https://heatmap-external-a.strava.com//tiles/ride/hot/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
             "attribution": "(C) OpenStreetMap contributors",
             "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "name": "OpenStreetMap.Mapnik",
-            "accessToken": "<insert your access token here>"
+            "name": "Strava.Ride",
+            "status": "broken"
+        },
+        "Run": {
+            "url": "https://heatmap-external-a.strava.com//tiles/run/bluered/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.Run",
+            "status": "broken"
+        },
+        "Water": {
+            "url": "https://heatmap-external-a.strava.com//tiles/water/blue/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.Water",
+            "status": "broken"
+        },
+        "Winter": {
+            "url": "https://heatmap-external-a.strava.com//tiles/winter/hot/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.Winter",
+            "status": "broken"
         }
     }
 }

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2375,28 +2375,32 @@
             "max_zoom": 9,
             "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "name": "NASAGIBS.ModisTerraBands721CR"
+            "name": "NASAGIBS.ModisTerraBands721CR",
+            "time": ""
         },
         "ModisAquaTrueColorCR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
             "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "name": "NASAGIBS.ModisAquaTrueColorCR"
+            "name": "NASAGIBS.ModisAquaTrueColorCR",
+            "time": ""
         },
         "ModisAquaBands721CR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
             "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "name": "NASAGIBS.ModisAquaTrueColorCR"
+            "name": "NASAGIBS.ModisAquaBands721CR",
+            "time": ""
         },
         "ViirsTrueColorCR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
             "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "name": "NASAGIBS.ViirsTrueColorCR"
+            "name": "NASAGIBS.ViirsTrueColorCR",
+            "time": ""
         }
     },
     "NLS": {
@@ -2939,35 +2943,40 @@
             "max_zoom": 15,
             "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
             "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
-            "name": "Strava.All"
+            "name": "Strava.All",
+            "status": "broken"
         },
         "Ride": {
             "url": "https://heatmap-external-a.strava.com//tiles/ride/hot/{z}/{x}/{y}.png?v=19",
             "max_zoom": 15,
             "attribution": "(C) OpenStreetMap contributors",
             "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "name": "Strava.Ride"
+            "name": "Strava.Ride",
+            "status": "broken"
         },
         "Run": {
             "url": "https://heatmap-external-a.strava.com//tiles/run/bluered/{z}/{x}/{y}.png?v=19",
             "max_zoom": 15,
             "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
             "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
-            "name": "Strava.Run"
+            "name": "Strava.Run",
+            "status": "broken"
         },
         "Water": {
             "url": "https://heatmap-external-a.strava.com//tiles/water/blue/{z}/{x}/{y}.png?v=19",
             "max_zoom": 15,
             "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
             "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
-            "name": "Strava.Water"
+            "name": "Strava.Water",
+            "status": "broken"
         },
         "Winter": {
             "url": "https://heatmap-external-a.strava.com//tiles/winter/hot/{z}/{x}/{y}.png?v=19",
             "max_zoom": 15,
             "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
             "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
-            "name": "Strava.Winter"
+            "name": "Strava.Winter",
+            "status": "broken"
         }
     }
 }

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -1,66 +1,11 @@
 {
     "OpenStreetMap": {
-        "Mapnik": {
-            "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-            "max_zoom": 19,
-            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "(C) OpenStreetMap contributors",
-            "name": "OpenStreetMap.Mapnik"
-        },
-        "DE": {
-            "url": "https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
+        "BlackAndWhite": {
+            "url": "http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png",
             "max_zoom": 18,
-            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) OpenStreetMap contributors",
-            "name": "OpenStreetMap.DE"
-        },
-        "CH": {
-            "url": "https://tile.osm.ch/switzerland/{z}/{x}/{y}.png",
-            "max_zoom": 18,
             "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "(C) OpenStreetMap contributors",
-            "bounds": [
-                [
-                    45,
-                    5
-                ],
-                [
-                    48,
-                    11
-                ]
-            ],
-            "name": "OpenStreetMap.CH"
-        },
-        "France": {
-            "url": "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
-            "max_zoom": 20,
-            "html_attribution": "&copy; OpenStreetMap France | &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "(C) OpenStreetMap France | (C) OpenStreetMap contributors",
-            "name": "OpenStreetMap.France"
-        },
-        "HOT": {
-            "url": "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
-            "max_zoom": 19,
-            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, Tiles style by <a href=\"https://www.hotosm.org/\" target=\"_blank\">Humanitarian OpenStreetMap Team</a> hosted by <a href=\"https://openstreetmap.fr/\" target=\"_blank\">OpenStreetMap France</a>",
-            "attribution": "(C) OpenStreetMap contributors, Tiles style by Humanitarian OpenStreetMap Team hosted by OpenStreetMap France",
-            "name": "OpenStreetMap.HOT"
-        },
-        "BZH": {
-            "url": "https://tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
-            "max_zoom": 19,
-            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, Tiles courtesy of <a href=\"http://www.openstreetmap.bzh/\" target=\"_blank\">Breton OpenStreetMap Team</a>",
-            "attribution": "(C) OpenStreetMap contributors, Tiles courtesy of Breton OpenStreetMap Team",
-            "bounds": [
-                [
-                    46.2,
-                    -5.5
-                ],
-                [
-                    50,
-                    0.7
-                ]
-            ],
-            "name": "OpenStreetMap.BZH"
+            "name": "OpenStreetMap.BlackAndWhite"
         }
     },
     "OpenSeaMap": {
@@ -2204,164 +2149,33 @@
         }
     },
     "NASAGIBS": {
-        "ModisTerraTrueColorCR": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
-            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
+        "ModisTerraBands721CR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "format": "jpg",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "MODIS_Terra_CorrectedReflectance_TrueColor",
-            "name": "NASAGIBS.ModisTerraTrueColorCR"
-        },
-        "ModisTerraBands367CR": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
+            "name": "NASAGIBS.ModisTerraBands721CR"
+        },
+        "ModisAquaTrueColorCR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "format": "jpg",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "MODIS_Terra_CorrectedReflectance_Bands367",
-            "name": "NASAGIBS.ModisTerraBands367CR"
-        },
-        "ViirsEarthAtNight2012": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
-            "max_zoom": 8,
-            "format": "jpg",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "VIIRS_CityLights_2012",
-            "name": "NASAGIBS.ViirsEarthAtNight2012"
+            "name": "NASAGIBS.ModisAquaTrueColorCR"
         },
-        "ModisTerraLSTDay": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+        "ModisAquaBands721CR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+            "max_zoom": 9,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
-            "max_zoom": 7,
-            "format": "png",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "MODIS_Terra_Land_Surface_Temp_Day",
-            "opacity": 0.75,
-            "name": "NASAGIBS.ModisTerraLSTDay"
+            "name": "NASAGIBS.ModisAquaTrueColorCR"
         },
-        "ModisTerraSnowCover": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+        "ViirsTrueColorCR": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+            "max_zoom": 9,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
-            "max_zoom": 8,
-            "format": "png",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "MODIS_Terra_Snow_Cover",
-            "opacity": 0.75,
-            "name": "NASAGIBS.ModisTerraSnowCover",
-            "status": "broken"
-        },
-        "ModisTerraAOD": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
-            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
-            "max_zoom": 6,
-            "format": "png",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "MODIS_Terra_Aerosol",
-            "opacity": 0.75,
-            "name": "NASAGIBS.ModisTerraAOD"
-        },
-        "ModisTerraChlorophyll": {
-            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
-            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
-            "bounds": [
-                [
-                    -85.0511287776,
-                    -179.999999975
-                ],
-                [
-                    85.0511287776,
-                    179.999999975
-                ]
-            ],
-            "min_zoom": 1,
-            "max_zoom": 7,
-            "format": "png",
-            "time": "",
-            "tilematrixset": "GoogleMapsCompatible_Level",
-            "variant": "MODIS_Terra_Chlorophyll_A",
-            "opacity": 0.75,
-            "name": "NASAGIBS.ModisTerraChlorophyll"
+            "name": "NASAGIBS.ViirsTrueColorCR"
         }
     },
     "NLS": {
@@ -2880,6 +2694,22 @@
             "language": "en-US",
             "timeStamp": "2021-05-08T09:03:00Z",
             "name": "AzureMaps.MicrosoftWeatherRadarMain"
+        }
+    },
+    "Gaode": {
+        "Normal": {
+            "url": "http://webrd01.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=7&x={x}&y={y}&z={z}",
+            "max_zoom": 19,
+            "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "html_attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "name": "Gaode.Normal"
+        },
+        "Satellite": {
+            "url": "http://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}",
+            "max_zoom": 19,
+            "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "html_attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+            "name": "Gaode.Satellite"
         }
     }
 }

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -1,5 +1,67 @@
 {
     "OpenStreetMap": {
+        "Mapnik": {
+            "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            "max_zoom": 19,
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) OpenStreetMap contributors",
+            "name": "OpenStreetMap.Mapnik"
+        },
+        "DE": {
+            "url": "https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
+            "max_zoom": 18,
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) OpenStreetMap contributors",
+            "name": "OpenStreetMap.DE"
+        },
+        "CH": {
+            "url": "https://tile.osm.ch/switzerland/{z}/{x}/{y}.png",
+            "max_zoom": 18,
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) OpenStreetMap contributors",
+            "bounds": [
+                [
+                    45,
+                    5
+                ],
+                [
+                    48,
+                    11
+                ]
+            ],
+            "name": "OpenStreetMap.CH"
+        },
+        "France": {
+            "url": "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
+            "max_zoom": 20,
+            "html_attribution": "&copy; OpenStreetMap France | &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) OpenStreetMap France | (C) OpenStreetMap contributors",
+            "name": "OpenStreetMap.France"
+        },
+        "HOT": {
+            "url": "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+            "max_zoom": 19,
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, Tiles style by <a href=\"https://www.hotosm.org/\" target=\"_blank\">Humanitarian OpenStreetMap Team</a> hosted by <a href=\"https://openstreetmap.fr/\" target=\"_blank\">OpenStreetMap France</a>",
+            "attribution": "(C) OpenStreetMap contributors, Tiles style by Humanitarian OpenStreetMap Team hosted by OpenStreetMap France",
+            "name": "OpenStreetMap.HOT"
+        },
+        "BZH": {
+            "url": "https://tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
+            "max_zoom": 19,
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, Tiles courtesy of <a href=\"http://www.openstreetmap.bzh/\" target=\"_blank\">Breton OpenStreetMap Team</a>",
+            "attribution": "(C) OpenStreetMap contributors, Tiles courtesy of Breton OpenStreetMap Team",
+            "bounds": [
+                [
+                    46.2,
+                    -5.5
+                ],
+                [
+                    50,
+                    0.7
+                ]
+            ],
+            "name": "OpenStreetMap.BZH"
+        },
         "BlackAndWhite": {
             "url": "http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png",
             "max_zoom": 18,
@@ -2149,6 +2211,165 @@
         }
     },
     "NASAGIBS": {
+        "ModisTerraTrueColorCR": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 9,
+            "format": "jpg",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "MODIS_Terra_CorrectedReflectance_TrueColor",
+            "name": "NASAGIBS.ModisTerraTrueColorCR"
+        },
+        "ModisTerraBands367CR": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 9,
+            "format": "jpg",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "MODIS_Terra_CorrectedReflectance_Bands367",
+            "name": "NASAGIBS.ModisTerraBands367CR"
+        },
+        "ViirsEarthAtNight2012": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 8,
+            "format": "jpg",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "VIIRS_CityLights_2012",
+            "name": "NASAGIBS.ViirsEarthAtNight2012"
+        },
+        "ModisTerraLSTDay": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 7,
+            "format": "png",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "MODIS_Terra_Land_Surface_Temp_Day",
+            "opacity": 0.75,
+            "name": "NASAGIBS.ModisTerraLSTDay"
+        },
+        "ModisTerraSnowCover": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 8,
+            "format": "png",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "MODIS_Terra_Snow_Cover",
+            "opacity": 0.75,
+            "name": "NASAGIBS.ModisTerraSnowCover",
+            "status": "broken"
+        },
+        "ModisTerraAOD": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 6,
+            "format": "png",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "MODIS_Terra_Aerosol",
+            "opacity": 0.75,
+            "name": "NASAGIBS.ModisTerraAOD"
+        },
+        "ModisTerraChlorophyll": {
+            "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}{max_zoom}/{z}/{y}/{x}.{format}",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+            "bounds": [
+                [
+                    -85.0511287776,
+                    -179.999999975
+                ],
+                [
+                    85.0511287776,
+                    179.999999975
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 7,
+            "format": "png",
+            "time": "",
+            "tilematrixset": "GoogleMapsCompatible_Level",
+            "variant": "MODIS_Terra_Chlorophyll_A",
+            "opacity": 0.75,
+            "name": "NASAGIBS.ModisTerraChlorophyll"
+        },
         "ModisTerraBands721CR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
@@ -2710,6 +2931,43 @@
             "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
             "html_attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
             "name": "Gaode.Satellite"
+        }
+    },
+    "Strava": {
+        "All": {
+            "url": "https://heatmap-external-a.strava.com//tiles/all/hot/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.All"
+        },
+        "Ride": {
+            "url": "https://heatmap-external-a.strava.com//tiles/ride/hot/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "(C) OpenStreetMap contributors",
+            "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "name": "Strava.Ride"
+        },
+        "Run": {
+            "url": "https://heatmap-external-a.strava.com//tiles/run/bluered/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.Run"
+        },
+        "Water": {
+            "url": "https://heatmap-external-a.strava.com//tiles/water/blue/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.Water"
+        },
+        "Winter": {
+            "url": "https://heatmap-external-a.strava.com//tiles/winter/hot/{z}/{x}/{y}.png?v=19",
+            "max_zoom": 15,
+            "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "html_attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2017</a>",
+            "name": "Strava.Winter"
         }
     }
 }


### PR DESCRIPTION
I have added some providers which were missing here and present in [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet/blob/master/ipyleaflet/basemaps.py)
Also while adding provider found an issue in `provider_sources/_compress_providers.py`
If Group is already present and if we add new basemaps to the same group then it is overriding the dictionary due to line https://github.com/geopandas/xyzservices/blob/1f6ac89f4aaf7ab04ab40f5c659c32f100b8c3c6/provider_sources/_compress_providers.py#L52

example:
`OpenStreetMap` group is already present, If I add a new entry in this group then as per existing code it will replace the value and will keep only the new value, it is not updating the dictionary.
Please correct me if I am wrong.
I have also created PR # https://github.com/jupyter-widgets/ipyleaflet/pull/857 in ipyleaflet to support xyzservices. 