### PR TITLE
TST: test providers requiring API token

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,8 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         environment-file: [ci/latest.yaml]
+    env:
+      THUNDERFOREST: ${{ secrets.THUNDERFOREST }}
 
     steps:
       - name: checkout repo

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,8 +28,6 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         environment-file: [ci/latest.yaml]
-    env:
-      THUNDERFOREST: ${{ secrets.THUNDERFOREST }}
 
     steps:
       - name: checkout repo
@@ -53,6 +51,8 @@ jobs:
 
       - name: run tests - bash
         shell: bash -l {0}
+        env:
+          THUNDERFOREST: ${{ secrets.THUNDERFOREST }}
         run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml
         if: matrix.os != 'windows-latest'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,15 +3,14 @@ name: Tests
 on:
   push:
     branches:
-      - '*'
+      - "*"
   pull_request:
     branches:
-      - '*'
+      - "*"
   schedule:
-      - cron: '59 23 * * 3'
+    - cron: "59 23 * * 3"
 
 jobs:
-
   Linting:
     runs-on: ubuntu-latest
 
@@ -28,6 +27,8 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         environment-file: [ci/latest.yaml]
+    env:
+      THUNDERFOREST: ${{ secrets.THUNDERFOREST }}
 
     steps:
       - name: checkout repo
@@ -37,7 +38,7 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: ${{ matrix.environment-file }}
-          micromamba-version: 'latest'
+          micromamba-version: "latest"
 
       - name: Install xyzservices
         shell: bash -l {0}
@@ -51,14 +52,12 @@ jobs:
 
       - name: run tests - bash
         shell: bash -l {0}
-        env:
-          THUNDERFOREST: ${{ secrets.THUNDERFOREST }}
-        run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml
+        run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
         if: matrix.os != 'windows-latest'
 
       - name: run tests - powershell
         shell: powershell
-        run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml
+        run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
         if: matrix.os == 'windows-latest'
 
       - uses: codecov/codecov-action@v2

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -37,7 +37,7 @@ def get_response(url):
     return r.status_code
 
 
-def get_test_result(provider):
+def get_test_result(provider, allow_403=True):
     if provider.get("status"):
         pytest.xfail("Provider is known to be broken.")
 
@@ -47,7 +47,7 @@ def get_test_result(provider):
         r = get_response(provider.build_url(z=z, x=x, y=y))
         assert r == requests.codes.ok
     except AssertionError as e:
-        if r == 403:
+        if r == 403 and allow_403:
             pytest.xfail("Provider not available due to API restrictions (Error 403).")
 
         elif r == 503:
@@ -91,8 +91,9 @@ def test_free_providers(name):
 def test_thunderforest(provider_name):
     try:
         token = os.environ["THUNDERFOREST"]
+        print(token, type(token))
     except KeyError:
         pytest.xfail("Mising API token.")
 
     provider = xyz.Thunderforest[provider_name](apikey=token)
-    get_test_result(provider)
+    get_test_result(provider, allow_403=False)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -84,16 +84,18 @@ def test_free_providers(name):
 
 
 # test providers requiring API keys. Store API keys in GitHub secrets and load them as
-# environment variables in CI Action
+# environment variables in CI Action. Note that env variable is loaded as empty on PRs
+# from a fork.
 
 
 @pytest.mark.parametrize("provider_name", xyz.Thunderforest)
 def test_thunderforest(provider_name):
     try:
         token = os.environ["THUNDERFOREST"]
-        print(token, type(token))
     except KeyError:
         pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
 
     provider = xyz.Thunderforest[provider_name](apikey=token)
     get_test_result(provider, allow_403=False)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -36,6 +36,7 @@ def get_response(url):
     r = s.get(url)
     return r.status_code
 
+
 def get_test_result(provider):
     if provider.get("status"):
         pytest.xfail("Provider is known to be broken.")
@@ -69,6 +70,7 @@ def get_test_result(provider):
         else:
             raise ValueError(f"Response code: {r}")
 
+
 @pytest.mark.parametrize("provider_name", xyz.flatten())
 def test_minimal_provider_metadata(provider_name):
     provider = xyz.flatten()[provider_name]
@@ -84,6 +86,7 @@ def test_free_providers(name):
 # test providers requiring API keys. Store API keys in GitHub secrets and load them as
 # environment variables in CI Action
 
+
 @pytest.mark.parametrize("provider_name", xyz.Thunderforest)
 def test_thunderforest(provider_name):
     try:
@@ -93,4 +96,3 @@ def test_thunderforest(provider_name):
 
     provider = xyz.Thunderforest[provider_name](apikey=token)
     get_test_result(provider)
-


### PR DESCRIPTION
I am trying to figure out a way of testing providers that require API tokens. It seems to be doable:

1. register and get API token
2. store it as a repository secret
3. load it in `tests.yaml`
4. load it via `os.environ` in tests

Note that secrets are loaded as empty strings if the PR is coming from a fork. We xfail in that case. I am going to merge this to trigger proper test and open a new PR adding other services as a branch of upstream.