### PR TITLE
TST: test more providers requiring API keys

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,13 @@ jobs:
         environment-file: [ci/latest.yaml]
     env:
       THUNDERFOREST: ${{ secrets.THUNDERFOREST }}
+      JAWG: ${{ secrets.JAWG }}
+      MAPBOX: ${{ secrets.MAPBOX }}
+      MAPTILER: ${{ secrets.MAPTILER }}
+      TOMTOM: ${{ secrets.TOMTOM }}
+      OPENWEATHERMAP: ${{ secrets.OPENWEATHERMAP }}
+      HEREV3: ${{ secrets.HEREV3 }}
+
 
     steps:
       - name: checkout repo

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,7 @@ jobs:
       TOMTOM: ${{ secrets.TOMTOM }}
       OPENWEATHERMAP: ${{ secrets.OPENWEATHERMAP }}
       HEREV3: ${{ secrets.HEREV3 }}
+      STADIA: ${{ secrets.STADIA }}
 
 
     steps:

--- a/doc/source/registration.md
+++ b/doc/source/registration.md
@@ -48,7 +48,7 @@ xyz.HEREv3.terrainDay(apiKey="my-private-api-key")
 You can still pass `app_id` and `app_code` in legacy projects:
 
 ```py
-xyz.HEREv3.terrainDay(app_id="my-private-app-id", app_code="my-app-code")
+xyz.HERE.terrainDay(app_id="my-private-app-id", app_code="my-app-code")
 ```
 
 ## Jawg Maps

--- a/doc/source/registration.md
+++ b/doc/source/registration.md
@@ -111,3 +111,11 @@ xyz.TomTom(apikey="<insert api_key here>")
 
 In order to use Stadia maps, you must [register](https://client.stadiamaps.com/signup/).
 Once registered, you can whitelist your domain within your account settings.
+
+Alternatively, you can use Stadia maps with an API token but you need to adapt a
+provider object to correct form.
+
+```py
+provider = xyz.Stadia.AlidadeSmooth(api_key="<insert api_key here>")
+provider["url"] = provider["url"] + "?api_key={api_key}"  # adding API key placeholder
+```

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -99,3 +99,83 @@ def test_thunderforest(provider_name):
 
     provider = xyz.Thunderforest[provider_name](apikey=token)
     get_test_result(provider, allow_403=False)
+
+
+@pytest.mark.parametrize("provider_name", xyz.Jawg)
+def test_jawg(provider_name):
+    try:
+        token = os.environ["JAWG"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.Jawg[provider_name](accessToken=token)
+    get_test_result(provider, allow_403=False)
+
+
+def test_mapbox():
+    try:
+        token = os.environ["MAPBOX"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.MapBox(accessToken=token)
+    get_test_result(provider, allow_403=False)
+
+
+@pytest.mark.parametrize("provider_name", xyz.MapTiler)
+def test_maptiler(provider_name):
+    try:
+        token = os.environ["MAPTILER"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.MapTiler[provider_name](key=token)
+    get_test_result(provider, allow_403=False)
+
+
+@pytest.mark.parametrize("provider_name", xyz.TomTom)
+def test_tomtom(provider_name):
+    try:
+        token = os.environ["TOMTOM"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.TomTom[provider_name](apikey=token)
+    get_test_result(provider, allow_403=False)
+
+
+@pytest.mark.parametrize("provider_name", xyz.OpenWeatherMap)
+def test_openweathermap(provider_name):
+    try:
+        token = os.environ["OPENWEATHERMAP"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.OpenWeatherMap[provider_name](apiKey=token)
+    get_test_result(provider, allow_403=False)
+
+
+@pytest.mark.parametrize("provider_name", xyz.HEREv3)
+def test_herev3(provider_name):
+    try:
+        token = os.environ["HEREV3"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.HEREv3[provider_name](apiKey=token)
+    get_test_result(provider, allow_403=False)
+
+# NOTE: AzureMaps are not tested as their free account is limited to
+# 5000 downloads (total, not per month)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -177,5 +177,19 @@ def test_herev3(provider_name):
     provider = xyz.HEREv3[provider_name](apiKey=token)
     get_test_result(provider, allow_403=False)
 
+
+@pytest.mark.parametrize("provider_name", xyz.Stadia)
+def test_stadia(provider_name):
+    try:
+        token = os.environ["STADIA"]
+    except KeyError:
+        pytest.xfail("Mising API token.")
+    if token == "":
+        pytest.xfail("Token empty.")
+
+    provider = xyz.Stadia[provider_name](api_key=token)
+    provider["url"] = provider["url"] + "?api_key={api_key}"
+    get_test_result(provider, allow_403=False)
+
 # NOTE: AzureMaps are not tested as their free account is limited to
 # 5000 downloads (total, not per month)


### PR DESCRIPTION
With this PR, all our providers are tested with two exceptions: `HERE` and `AzureMaps`.

`HERE` contains legacy authentication requiring `app_id` and `app_code` which is not possible to obtain anymore. It has been replaced by `HEREv3` with `apiKey`. That one is tested.

`AzureMaps` have a free tier limited to 5000 requests in total, not per month. If I created a token on my account as I did with other services, it would eventually overflow and charged me. Hence not tested at the moment.