### PR TITLE
CI: fetch tiles only under ubuntu

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,6 @@ jobs:
       HEREV3: ${{ secrets.HEREV3 }}
       STADIA: ${{ secrets.STADIA }}
 
-
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
@@ -60,12 +59,17 @@ jobs:
 
       - name: run tests - bash
         shell: bash -l {0}
-        run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
+        run: pytest -v . -m "not request" --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
         if: matrix.os != 'windows-latest'
 
       - name: run tests - powershell
         shell: powershell
-        run: pytest -v . --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
+        run: pytest -v . -m "not request" --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
         if: matrix.os == 'windows-latest'
+
+      - name: test providers - bash
+        shell: bash -l {0}
+        run: pytest -v . -m request --cov=xyzservices --cov-append --cov-report term-missing --cov-report xml --color=yes
+        if: matrix.os == 'ubuntu-latest'
 
       - uses: codecov/codecov-action@v2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    request: fetching tiles from remote server.

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -79,7 +79,7 @@ def test_minimal_provider_metadata(provider_name):
     provider = xyz.flatten()[provider_name]
     check_provider(provider)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("name", flat_free)
 def test_free_providers(name):
     provider = flat_free[name]
@@ -90,7 +90,7 @@ def test_free_providers(name):
 # environment variables in CI Action. Note that env variable is loaded as empty on PRs
 # from a fork.
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.Thunderforest)
 def test_thunderforest(provider_name):
     try:
@@ -103,7 +103,7 @@ def test_thunderforest(provider_name):
     provider = xyz.Thunderforest[provider_name](apikey=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.Jawg)
 def test_jawg(provider_name):
     try:
@@ -116,7 +116,7 @@ def test_jawg(provider_name):
     provider = xyz.Jawg[provider_name](accessToken=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 def test_mapbox():
     try:
         token = os.environ["MAPBOX"]
@@ -128,7 +128,7 @@ def test_mapbox():
     provider = xyz.MapBox(accessToken=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.MapTiler)
 def test_maptiler(provider_name):
     try:
@@ -141,7 +141,7 @@ def test_maptiler(provider_name):
     provider = xyz.MapTiler[provider_name](key=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.TomTom)
 def test_tomtom(provider_name):
     try:
@@ -154,7 +154,7 @@ def test_tomtom(provider_name):
     provider = xyz.TomTom[provider_name](apikey=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.OpenWeatherMap)
 def test_openweathermap(provider_name):
     try:
@@ -167,7 +167,7 @@ def test_openweathermap(provider_name):
     provider = xyz.OpenWeatherMap[provider_name](apiKey=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.HEREv3)
 def test_herev3(provider_name):
     try:
@@ -180,7 +180,7 @@ def test_herev3(provider_name):
     provider = xyz.HEREv3[provider_name](apiKey=token)
     get_test_result(provider, allow_403=False)
 
-
+@pytest.mark.request
 @pytest.mark.parametrize("provider_name", xyz.Stadia)
 def test_stadia(provider_name):
     try:


### PR DESCRIPTION
We don't need to check if the tiles exist in all environments. And due to the limits of free tiers we use in CI, we should try to minimize the number of requests.

Marking tests that fetch tiles from a remote server and running those only in ubuntu env, so it is done once, not 3x.