### PR TITLE
ENH: implement Bunch.query_name()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+xyzservices 2021.09.1 (September ??, 2021)
+-----------------------------------------
+
+New functionality:
+
+- Added ``Bunch.query_name()`` method allowing to fetch the ``TileProvider`` object based on the name with flexible formatting. (#93)
+
+
 xyzservices 2021.09.0 (September 3, 2021)
 -----------------------------------------
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -14,7 +14,7 @@ Python API
 
 .. autoclass:: Bunch
    :exclude-members: clear, copy, fromkeys, get, items, keys, pop, popitem, setdefault, update, values
-   :members: filter, flatten
+   :members: filter, flatten, query_name
 
 Providers JSON
 --------------

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -258,3 +258,6 @@ def test_query_name():
         queried = xyz.query_name(option)
         assert isinstance(queried, TileProvider)
         assert queried.name == "CartoDB.Positron"
+
+    with pytest.raises(ValueError, match="No matching provider found"):
+        xyz.query_name("i don't exist")

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -241,3 +241,20 @@ def test_filter(test_bunch):
         return False
 
     assert len(test_bunch.filter(function=custom).flatten()) == 2
+
+
+def test_query_name():
+    options = [
+        "CartoDB Positron",
+        "cartodbpositron",
+        "cartodb-positron",
+        "carto db/positron",
+        "CARTO_DB_POSITRON",
+        "CartoDB.Positron",
+        "Carto,db,positron",
+    ]
+
+    for option in options:
+        queried = xyz.query_name(option)
+        assert isinstance(queried, TileProvider)
+        assert queried.name == "CartoDB.Positron"

--- a/xyzservices/lib.py
+++ b/xyzservices/lib.py
@@ -256,8 +256,9 @@ class Bunch(dict):
         """Return :class:`TileProvider` based on the name query
 
         Returns a matching :class:`TileProvider` from the :class:`Bunch` if the ``name``
-        can be parsed into the string matching the provider's name. See examples for
-        details.
+        contains the same letters in the same order as the provider's name irrespective
+        of the letter case, spaces, dashes and other characters.
+        See examples for details.
 
         Parameters
         ----------

--- a/xyzservices/lib.py
+++ b/xyzservices/lib.py
@@ -252,6 +252,49 @@ class Bunch(dict):
             function=function,
         )
 
+    def query_name(self, name: str) -> TileProvider:
+        """Return :class:`TileProvider` based on the name query
+
+        Returns a matching :class:`TileProvider` from the :class:`Bunch` if the ``name``
+        can be parsed into the string matchinch provider's name. See examples for
+        details.
+
+        Parameters
+        ----------
+        name : str
+            Name of the tile provider. Formatting does not matter.
+
+        Returns
+        -------
+        match: TileProvider
+
+        Examples
+        --------
+        >>> import xyzservices.providers as xyz
+
+        All these queries return the same ``CartoDB.Positron`` TileProvider:
+
+        >>> xyz.query_name("CartoDB Positron")
+        >>> xyz.query_name("cartodbpositron")
+        >>> xyz.query_name("cartodb-positron")
+        >>> xyz.query_name("carto db/positron")
+        >>> xyz.query_name("CARTO_DB_POSITRON")
+        >>> xyz.query_name("CartoDB.Positron")
+
+        """
+        xyz_flat_lower = {
+            k.replace(".", "").lower(): v for k, v in self.flatten().items()
+        }
+        name_clean = name
+        remove = "., -_/"
+        for string in remove:
+            name_clean = name_clean.replace(string, "")
+        name_clean = name_clean.lower()
+        if name_clean in xyz_flat_lower:
+            return xyz_flat_lower[name_clean]
+
+        raise ValueError(f"No matching provider found for the query '{name}'.")
+
 
 class TileProvider(Bunch):
     """

--- a/xyzservices/lib.py
+++ b/xyzservices/lib.py
@@ -256,7 +256,7 @@ class Bunch(dict):
         """Return :class:`TileProvider` based on the name query
 
         Returns a matching :class:`TileProvider` from the :class:`Bunch` if the ``name``
-        can be parsed into the string matchinch provider's name. See examples for
+        can be parsed into the string matching the provider's name. See examples for
         details.
 
         Parameters


### PR DESCRIPTION
`query_name()` returns the TileProvider object based on the lowercase string stripped of additional characters. E.g.:

All these queries return the same ``CartoDB.Positron`` TileProvider:
```py
        >>> xyz.query_name("CartoDB Positron")
        >>> xyz.query_name("cartodbpositron")
        >>> xyz.query_name("cartodb-positron")
        >>> xyz.query_name("carto db/positron")
        >>> xyz.query_name("CARTO_DB_POSITRON")
        >>> xyz.query_name("CartoDB.Positron")
```

It makes easier implementing relaxed string input in downstream, e.g. https://github.com/geopandas/geopandas/pull/1953#discussion_r69749762

An implementation in GeoPandas then can be something along this:

```py
def explore(... tiles=None...):
    try:
        tiles = xyz.query_name(tiles)
    except ValueError:
        pass
```

This either replaces the string with TileProvider object or leaves it as it is, assuming it is xyz URL to be passed to folium.

