### PR TITLE
do not package a tests module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     author="Dani Arribas-Bel, Martin Fleischmann",
     author_email="daniel.arribas.bel@gmail.com, martin@martinfleischmann.net",
     license="3-Clause BSD",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests"]),
     python_requires=">=3.7",
     include_package_data=True,
     package_data={


### PR DESCRIPTION
The current setup packages the tests directory as a module. B/c many Python libraries make that mistake it causes clobber errors downstream. This PR removes this behavior but if the authors want to ship the tests with the library the "right" thing to do is to move it inside the module folder. 