### PR TITLE
Add Esri Arctic and Antarctic Basemaps

### DIFF
--- a/provider_sources/xyzservices-providers.json
+++ b/provider_sources/xyzservices-providers.json
@@ -65,6 +65,65 @@
             "name": "NASAGIBS.BlueMarble"
         }
     },
+    "Esri": {
+        "ArcticOceanBase": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Ocean_Base/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Arctic_Ocean_Base",
+            "html_attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "max_zoom": 24,
+            "name": "Esri.ArcticOceanBase",
+            "crs": "EPSG:5936",
+            "bounds": [
+                [
+                    -2623285.8808999992907047,
+                    -2623285.8808999992907047
+                ],
+                [
+                    6623285.8803000003099442,
+                    6623285.8803000003099442
+                ]
+            ]
+        },
+        "ArcticOceanReference": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Ocean_Reference/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Arctic_Ocean_Reference",
+            "html_attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "max_zoom": 24,
+            "name": "Esri.ArcticOceanReference",
+            "crs": "EPSG:5936",
+            "bounds": [
+                [
+                    -2623285.8808999992907047,
+                    -2623285.8808999992907047
+                ],
+                [
+                    6623285.8803000003099442,
+                    6623285.8803000003099442
+                ]
+            ]
+        },
+        "AntarcticBasemap": {
+            "url": "https://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/Antarctic_Basemap/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Antarctic_Basemap",
+            "html_attribution":"Imagery provided by NOAA National Centers for Environmental Information (NCEI); International Bathymetric Chart of the Southern Ocean (IBCSO); General Bathymetric Chart of the Oceans (GEBCO).",
+            "attribution":"Imagery provided by NOAA National Centers for Environmental Information (NCEI); International Bathymetric Chart of the Southern Ocean (IBCSO); General Bathymetric Chart of the Oceans (GEBCO).",
+            "max_zoom": 9,
+            "name": "Esri.AntarcticBasemap",
+            "crs": "EPSG:3031",
+            "bounds": [
+                [
+                    -4524583.19363305,
+                    -4524449.487765655
+                ],
+                [
+                    4524449.4877656475,
+                    4524583.193633042
+                ]
+            ]
+        }
+    },
     "Gaode": {
         "Normal": {
             "url": "http://webrd01.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=7&x={x}&y={y}&z={z}",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -804,6 +804,63 @@
             "attribution": "Tiles (C) Esri -- Esri, DeLorme, NAVTEQ",
             "max_zoom": 16,
             "name": "Esri.WorldGrayCanvas"
+        },
+        "ArcticOceanBase": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Ocean_Base/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Arctic_Ocean_Base",
+            "html_attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "max_zoom": 24,
+            "name": "Esri.ArcticOceanBase",
+            "crs": "EPSG:5936",
+            "bounds": [
+                [
+                    -2623285.8808999993,
+                    -2623285.8808999993
+                ],
+                [
+                    6623285.8803,
+                    6623285.8803
+                ]
+            ]
+        },
+        "ArcticOceanReference": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Ocean_Reference/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Arctic_Ocean_Reference",
+            "html_attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+            "max_zoom": 24,
+            "name": "Esri.ArcticOceanReference",
+            "crs": "EPSG:5936",
+            "bounds": [
+                [
+                    -2623285.8808999993,
+                    -2623285.8808999993
+                ],
+                [
+                    6623285.8803,
+                    6623285.8803
+                ]
+            ]
+        },
+        "AntarcticBasemap": {
+            "url": "https://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/Antarctic_Basemap/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Antarctic_Basemap",
+            "html_attribution": "Imagery provided by NOAA National Centers for Environmental Information (NCEI); International Bathymetric Chart of the Southern Ocean (IBCSO); General Bathymetric Chart of the Oceans (GEBCO).",
+            "attribution": "Imagery provided by NOAA National Centers for Environmental Information (NCEI); International Bathymetric Chart of the Southern Ocean (IBCSO); General Bathymetric Chart of the Oceans (GEBCO).",
+            "max_zoom": 9,
+            "name": "Esri.AntarcticBasemap",
+            "crs": "EPSG:3031",
+            "bounds": [
+                [
+                    -4524583.19363305,
+                    -4524449.487765655
+                ],
+                [
+                    4524449.4877656475,
+                    4524583.193633042
+                ]
+            ]
         }
     },
     "OpenWeatherMap": {

--- a/xyzservices/tests/test_providers.py
+++ b/xyzservices/tests/test_providers.py
@@ -62,7 +62,13 @@ def get_test_result(provider, allow_403=True):
         # check another tiles
         elif r == 404:
             # in some cases, the computed tile is not availble. trying known tiles.
-            options = [(12, 2154, 1363), (6, 13, 21), (16, 33149, 22973)]
+            options = [
+                (12, 2154, 1363),
+                (6, 13, 21),
+                (16, 33149, 22973),
+                (0, 0, 0),
+                (2, 6, 7),
+            ]
             results = []
             for o in options:
                 z, x, y = o


### PR DESCRIPTION
Adding polar projected Arctic and Antarctic Basemaps provided by Esri
* [Map Viewer for Arctic Ocean Basemap](https://www.arcgis.com/apps/mapviewer/index.html?webmap=c7381cb155a043a2bba2b84566677262)
* [Map Viewer for Antarctic Ocean Basemap](https://www.arcgis.com/apps/mapviewer/index.html?webmap=d13b9d10219e4429974e48368b64e41f)

xyzservices-providers.json has been updated with the new sources and the compressed file has been made