### PR TITLE
Add Esri Arctic Imagery and NASA ASTER GDEM

### DIFF
--- a/provider_sources/xyzservices-providers.json
+++ b/provider_sources/xyzservices-providers.json
@@ -12,7 +12,7 @@
         "ModisTerraBands721CR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ModisTerraBands721CR",
             "time": ""
@@ -20,7 +20,7 @@
         "ModisAquaTrueColorCR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ModisAquaTrueColorCR",
             "time": ""
@@ -28,7 +28,7 @@
         "ModisAquaBands721CR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ModisAquaBands721CR",
             "time": ""
@@ -36,7 +36,7 @@
         "ViirsTrueColorCR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ViirsTrueColorCR",
             "time": ""
@@ -44,7 +44,7 @@
         "BlueMarble3413": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3413/best/BlueMarble_NextGeneration/default/EPSG3413_500m/{z}/{y}/{x}.jpeg",
             "max_zoom": 5,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble3413",
             "crs": "EPSG:3413"
@@ -52,7 +52,7 @@
         "BlueMarble3031": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3031/best/BlueMarble_NextGeneration/default/EPSG3031_500m/{z}/{y}/{x}.jpeg",
             "max_zoom": 5,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble3031",
             "crs": "EPSG:3031"
@@ -60,14 +60,14 @@
         "BlueMarble": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/BlueMarble_NextGeneration/default/EPSG3857_500m/{z}/{y}/{x}.jpeg",
             "max_zoom": 8,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble"
         },
         "ASTER_GDEM_Greyscale_Shaded_Relief": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/ASTER_GDEM_Greyscale_Shaded_Relief/default/GoogleMapsCompatible_Level12/{z}/{y}/{x}.jpg",
             "max_zoom": 12,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ASTER_GDEM_Greyscale_Shaded_Relief"
         }

--- a/provider_sources/xyzservices-providers.json
+++ b/provider_sources/xyzservices-providers.json
@@ -74,7 +74,7 @@
     },
     "Esri": {
         "ArcticImagery": {
-            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/{variant}/MapServer/tile/{z}/{y}/{x}",
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Imagery/MapServer/tile/{z}/{y}/{x}",
             "variant": "Arctic_Imagery",
             "html_attribution": "Earthstar Geographics",
             "attribution": "Earthstar Geographics",
@@ -127,6 +127,25 @@
                 [
                     6623285.8803000003099442,
                     6623285.8803000003099442
+                ]
+            ]
+        },
+        "AntarcticImagery": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Antarctic_Imagery/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Antarctic_Imagery",
+            "html_attribution": "Earthstar Geographics",
+            "attribution": "Earthstar Geographics",
+            "max_zoom": 24,
+            "name": "Esri.AntarcticImagery",
+            "crs": "EPSG:3031",
+            "bounds": [
+                [
+                    -9913957.327914657,
+                    -5730886.461772691
+                ],
+                [
+                    9913957.327914657,
+                    5730886.461773157
                 ]
             ]
         },

--- a/provider_sources/xyzservices-providers.json
+++ b/provider_sources/xyzservices-providers.json
@@ -63,9 +63,35 @@
             "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble"
+        },
+        "ASTER_GDEM_Greyscale_Shaded_Relief": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/ASTER_GDEM_Greyscale_Shaded_Relief/default/GoogleMapsCompatible_Level12/{z}/{y}/{x}.jpg",
+            "max_zoom": 12,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "name": "NASAGIBS.ASTER_GDEM_Greyscale_Shaded_Relief"
         }
     },
     "Esri": {
+        "ArcticImagery": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/{variant}/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Arctic_Imagery",
+            "html_attribution": "Earthstar Geographics",
+            "attribution": "Earthstar Geographics",
+            "max_zoom": 24,
+            "name": "Esri.ArcticImagery",
+            "crs": "EPSG:5936",
+            "bounds": [
+                [
+                    -2623285.8808999992907047,
+                    -2623285.8808999992907047
+                ],
+                [
+                    6623285.8803000003099442,
+                    6623285.8803000003099442
+                ]
+            ]
+        },
         "ArcticOceanBase": {
             "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Ocean_Base/MapServer/tile/{z}/{y}/{x}",
             "variant": "Arctic_Ocean_Base",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -776,6 +776,25 @@
             "max_zoom": 16,
             "name": "Esri.WorldGrayCanvas"
         },
+        "ArcticImagery": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/{variant}/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Arctic_Imagery",
+            "html_attribution": "Earthstar Geographics",
+            "attribution": "Earthstar Geographics",
+            "max_zoom": 24,
+            "name": "Esri.ArcticImagery",
+            "crs": "EPSG:5936",
+            "bounds": [
+                [
+                    -2623285.8808999993,
+                    -2623285.8808999993
+                ],
+                [
+                    6623285.8803,
+                    6623285.8803
+                ]
+            ]
+        },
         "ArcticOceanBase": {
             "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Ocean_Base/MapServer/tile/{z}/{y}/{x}",
             "variant": "Arctic_Ocean_Base",
@@ -2543,6 +2562,13 @@
             "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble"
+        },
+        "ASTER_GDEM_Greyscale_Shaded_Relief": {
+            "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/ASTER_GDEM_Greyscale_Shaded_Relief/default/GoogleMapsCompatible_Level12/{z}/{y}/{x}.jpg",
+            "max_zoom": 12,
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "name": "NASAGIBS.ASTER_GDEM_Greyscale_Shaded_Relief"
         }
     },
     "NLS": {

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2530,7 +2530,7 @@
         "ModisTerraBands721CR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ModisTerraBands721CR",
             "time": ""
@@ -2538,7 +2538,7 @@
         "ModisAquaTrueColorCR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ModisAquaTrueColorCR",
             "time": ""
@@ -2546,7 +2546,7 @@
         "ModisAquaBands721CR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ModisAquaBands721CR",
             "time": ""
@@ -2554,7 +2554,7 @@
         "ViirsTrueColorCR": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default/{time}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
             "max_zoom": 9,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ViirsTrueColorCR",
             "time": ""
@@ -2562,7 +2562,7 @@
         "BlueMarble3413": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3413/best/BlueMarble_NextGeneration/default/EPSG3413_500m/{z}/{y}/{x}.jpeg",
             "max_zoom": 5,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble3413",
             "crs": "EPSG:3413"
@@ -2570,7 +2570,7 @@
         "BlueMarble3031": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3031/best/BlueMarble_NextGeneration/default/EPSG3031_500m/{z}/{y}/{x}.jpeg",
             "max_zoom": 5,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble3031",
             "crs": "EPSG:3031"
@@ -2578,14 +2578,14 @@
         "BlueMarble": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/BlueMarble_NextGeneration/default/EPSG3857_500m/{z}/{y}/{x}.jpeg",
             "max_zoom": 8,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.BlueMarble"
         },
         "ASTER_GDEM_Greyscale_Shaded_Relief": {
             "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/ASTER_GDEM_Greyscale_Shaded_Relief/default/GoogleMapsCompatible_Level12/{z}/{y}/{x}.jpg",
             "max_zoom": 12,
-            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+            "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
             "html_attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
             "name": "NASAGIBS.ASTER_GDEM_Greyscale_Shaded_Relief"
         }

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -777,7 +777,7 @@
             "name": "Esri.WorldGrayCanvas"
         },
         "ArcticImagery": {
-            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/{variant}/MapServer/tile/{z}/{y}/{x}",
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Arctic_Imagery/MapServer/tile/{z}/{y}/{x}",
             "variant": "Arctic_Imagery",
             "html_attribution": "Earthstar Geographics",
             "attribution": "Earthstar Geographics",
@@ -830,6 +830,25 @@
                 [
                     6623285.8803,
                     6623285.8803
+                ]
+            ]
+        },
+        "AntarcticImagery": {
+            "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Polar/Antarctic_Imagery/MapServer/tile/{z}/{y}/{x}",
+            "variant": "Antarctic_Imagery",
+            "html_attribution": "Earthstar Geographics",
+            "attribution": "Earthstar Geographics",
+            "max_zoom": 24,
+            "name": "Esri.AntarcticImagery",
+            "crs": "EPSG:3031",
+            "bounds": [
+                [
+                    -9913957.327914657,
+                    -5730886.461772691
+                ],
+                [
+                    9913957.327914657,
+                    5730886.461773157
                 ]
             ]
         },


### PR DESCRIPTION
- Adding polar projected Arctic Ocean Imagery provided by Esri
[Map Viewer for Arctic Ocean Imagery](https://www.arcgis.com/apps/mapviewer/index.html?webmap=7ec08e5438304dbfa1e26181503e6fa8)

- Adding polar projected Antarctic Imagery provided by Esri
[Map Viewer for Antarctic Imagery](https://www.arcgis.com/apps/mapviewer/index.html?webmap=6553466517dd4d5e8b0c518b8d6b64cb)

 - Adding NASA ASTER GDEM
[EOSDIS WorldView with NASA ASTER GDEM](https://worldview.earthdata.nasa.gov/?l=ASTER_GDEM_Greyscale_Shaded_Relief)

xyzservices-providers.json has been updated with the new sources and the compressed file has been made