### PR TITLE
DOC: Fix building documentation out of source tree #117

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath("../.."))
 import xyzservices  # noqa
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
This fixes https://github.com/geopandas/xyzservices/issues/117
It allows build documentation witout have module installd and
it adds path to `xyzservices` code to the `sys.path`
That kind of adjustment is suggested to use in ossifial sphinx
example conf.py file
https://www.sphinx-doc.org/en/master/usage/configuration.html#example-of-configuration-file

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>