### PR TITLE
TST: skip Stadia tiles in tests

### DIFF
--- a/xyzservices/tests/test_providers.py
+++ b/xyzservices/tests/test_providers.py
@@ -102,6 +102,8 @@ def test_minimal_provider_metadata(provider_name):
 @pytest.mark.parametrize("name", flat_free)
 def test_free_providers(name):
     provider = flat_free[name]
+    if "Stadia" in name:
+        pytest.skip("Stadia doesn't support tile download in this way.")
     get_test_result(provider)
 
 


### PR DESCRIPTION
Stadia changed their conditions and we no longer can download PNGs as we do in our CI. Skipping.