### PR TITLE
Added Stadia Maps' Alidade Satellite tile source.

### DIFF
--- a/provider_sources/leaflet-providers-parsed.json
+++ b/provider_sources/leaflet-providers-parsed.json
@@ -134,6 +134,16 @@
         "name": "SafeCast"
     },
     "Stadia": {
+        "AlidadeSatellite": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; CNES, Distribution Airbus DS, &copy; Airbus DS, &copy; PlanetObserver (Contains Copernicus Data) | &copy; <a href=\"https://stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a>",
+            "attribution": "(C) CNES, Distribution Airbus DS, (C) Airbus DS, (C) PlanetObserver (Contains Copernicus Data), (C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "alidade_satellite",
+            "ext": "jpg",
+            "name": "Stadia.AlidadeSatellite"
+        },
         "AlidadeSmooth": {
             "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
             "min_zoom": 0,

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -141,6 +141,16 @@
         "name": "SafeCast"
     },
     "Stadia": {
+        "AlidadeSatellite": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; CNES, Distribution Airbus DS, &copy; Airbus DS, &copy; PlanetObserver (Contains Copernicus Data) | &copy; <a href=\"https://stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a>",
+            "attribution": "(C) CNES, Distribution Airbus DS, (C) Airbus DS, (C) PlanetObserver (Contains Copernicus Data), (C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "alidade_satellite",
+            "ext": "jpg",
+            "name": "Stadia.AlidadeSatellite"
+        },
         "AlidadeSmooth": {
             "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
             "min_zoom": 0,


### PR DESCRIPTION
I added the Stadia Maps' Alidade Satellite tile source as an option:  https://docs.stadiamaps.com/map-styles/alidade-satellite/

This now completes their offerings:  https://docs.stadiamaps.com/themes/