### PR TITLE
Migrate ign wmts services

### DIFF
--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -169,6 +169,7 @@ for i in range(len(layers_list)):
         "variant": variant,
         "name": "GeoportailFrance." + name,
         "TileMatrixSet": TileMatrixSet,
+        "apikey": "your_api_key_here",
     }
 
     # Handle broken providers

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -100,8 +100,14 @@ for i in range(len(layers_list)):
     variant = layer.get("ows:Identifier")
 
     # Rename for better readability
-    name_parts = [part.lower().capitalize().replace("-", "_") for part in variant.split(".")]
-    name = "_".join(name_parts)
+    name = ""
+    if "." not in variant:
+        name = variant.lower().capitalize()
+    else:
+        name = variant.split(".")[0].lower().capitalize()
+        for i in range(1, len(variant.split("."))):
+            name = name + "_" + (variant.split(".")[i]).lower().capitalize()
+            name = name.replace("-", "_")
 
     # Rename for better readability (Frequent cases)
     variant_to_name = {

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -180,22 +180,14 @@ for i in range(len(layers_list)):
 
     # Handle broken providers
     possibly_broken_providers = [
-        # "Points_Injection_Biomethane",
-        # "Ocsge_Usage_2016",
-        # "Ocsge_Usage_2011",
-        # "Ocsge_Couverture_2016",
-        # "Ocsge_Couverture_2014",
-        # "Orthoimagery_Orthophotos_Geneve",
-        # "Orthoimagery_Orthophotos_Coast2000",
-        # "Ocsge_Couverture_2011",
-        # "Ocsge_Couverture_2002",
-        # "Ocsge_Constructions_2016",
-        # "Ocsge_Constructions_2014",
-        # "Ocsge_Constructions_2011",
-        # "Ocsge_Constructions_2002",
-        # "Ocsge_Usage_2002",
-        # "Ocsge_Usage_2014",
-        # "Pcrs_Lamb93"
+        "Ocsge_Constructions_2002",
+        "Ocsge_Constructions_2014",
+        "Orthoimagery_Orthophotos_Coast2000",
+        "Ocsge_Couverture_2002",
+        "Ocsge_Couverture_2014",
+        "Ocsge_Usage_2002",
+        "Ocsge_Usage_2014",
+        "Pcrs_Lamb93",
     ]
 
     if name in possibly_broken_providers:

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -186,7 +186,10 @@ for i in range(len(layers_list)):
         "Ocsge_Constructions_2016",
         "Ocsge_Constructions_2014",
         "Ocsge_Constructions_2011",
-        "Ocsge_Constructions_2002"
+        "Ocsge_Constructions_2002",
+        "Ocsge_Usage_2002",
+        "Ocsge_Usage_2014",
+        "Pcrs_Lamb93"
     ]
 
     if name in possibly_broken_providers:

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -171,5 +171,25 @@ for i in range(len(layers_list)):
         "TileMatrixSet": TileMatrixSet,
     }
 
+    # Handle broken providers
+    possibly_broken_providers = [
+        "Points_Injection_Biomethane",
+        "Ocsge_Usage_2016",
+        "Ocsge_Usage_2011",
+        "Ocsge_Couverture_2016",
+        "Ocsge_Couverture_2014",
+        "Orthoimagery_Orthophotos_Geneve",
+        "Orthoimagery_Orthophotos_Coast2000",
+        "Ocsge_Couverture_2011",
+        "Ocsge_Couverture_2002",
+        "Ocsge_Constructions_2016",
+        "Ocsge_Constructions_2014",
+        "Ocsge_Constructions_2011",
+        "Ocsge_Constructions_2002"
+    ]
+
+    if name in possibly_broken_providers:
+        leaflet["GeoportailFrance"][name]["status"] = "broken"
+
 with open("../xyzservices/data/providers.json", "w") as f:
     json.dump(leaflet, f, indent=4)

--- a/provider_sources/_compress_providers.py
+++ b/provider_sources/_compress_providers.py
@@ -180,22 +180,22 @@ for i in range(len(layers_list)):
 
     # Handle broken providers
     possibly_broken_providers = [
-        "Points_Injection_Biomethane",
-        "Ocsge_Usage_2016",
-        "Ocsge_Usage_2011",
-        "Ocsge_Couverture_2016",
-        "Ocsge_Couverture_2014",
-        "Orthoimagery_Orthophotos_Geneve",
-        "Orthoimagery_Orthophotos_Coast2000",
-        "Ocsge_Couverture_2011",
-        "Ocsge_Couverture_2002",
-        "Ocsge_Constructions_2016",
-        "Ocsge_Constructions_2014",
-        "Ocsge_Constructions_2011",
-        "Ocsge_Constructions_2002",
-        "Ocsge_Usage_2002",
-        "Ocsge_Usage_2014",
-        "Pcrs_Lamb93"
+        # "Points_Injection_Biomethane",
+        # "Ocsge_Usage_2016",
+        # "Ocsge_Usage_2011",
+        # "Ocsge_Couverture_2016",
+        # "Ocsge_Couverture_2014",
+        # "Orthoimagery_Orthophotos_Geneve",
+        # "Orthoimagery_Orthophotos_Coast2000",
+        # "Ocsge_Couverture_2011",
+        # "Ocsge_Couverture_2002",
+        # "Ocsge_Constructions_2016",
+        # "Ocsge_Constructions_2014",
+        # "Ocsge_Constructions_2011",
+        # "Ocsge_Constructions_2002",
+        # "Ocsge_Usage_2002",
+        # "Ocsge_Usage_2014",
+        # "Pcrs_Lamb93"
     ]
 
     if name in possibly_broken_providers:

--- a/provider_sources/leaflet-providers-parsed.json
+++ b/provider_sources/leaflet-providers-parsed.json
@@ -2365,7 +2365,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb63k1885",
-            "name": "NLS.osgb63k1885"
+            "name": "NLS.osgb63k1885",
+            "apikey": "<insert your API key here>"
         },
         "osgb1888": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2384,7 +2385,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb1888",
-            "name": "NLS.osgb1888"
+            "name": "NLS.osgb1888",
+            "apikey": "<insert your API key here>"
         },
         "osgb10k1888": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2403,7 +2405,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb10k1888",
-            "name": "NLS.osgb10k1888"
+            "name": "NLS.osgb10k1888",
+            "apikey": "<insert your API key here>"
         },
         "osgb1919": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2422,7 +2425,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb1919",
-            "name": "NLS.osgb1919"
+            "name": "NLS.osgb1919",
+            "apikey": "<insert your API key here>"
         },
         "osgb25k1937": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2441,7 +2445,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb25k1937",
-            "name": "NLS.osgb25k1937"
+            "name": "NLS.osgb25k1937",
+            "apikey": "<insert your API key here>"
         },
         "osgb63k1955": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2460,7 +2465,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb63k1955",
-            "name": "NLS.osgb63k1955"
+            "name": "NLS.osgb63k1955",
+            "apikey": "<insert your API key here>"
         },
         "oslondon1k1893": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",

--- a/provider_sources/leaflet-providers-parsed.json
+++ b/provider_sources/leaflet-providers-parsed.json
@@ -2648,70 +2648,70 @@
     },
     "GeoportailFrance": {
         "plan": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\" href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
                 [
-                    -75,
-                    -180
+                    -85.0,
+                    -175.0
                 ],
                 [
-                    81,
-                    180
+                    85.0,
+                    175.0
                 ]
             ],
-            "min_zoom": 2,
-            "max_zoom": 18,
-            "apikey": "choisirgeoportail",
+            "min_zoom": 0,
+            "max_zoom": 19,
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
-            "name": "GeoportailFrance.plan"
+            "name": "GeoportailFrance.plan",
+            "TileMatrixSet": "PM"
         },
         "parcels": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\" href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
                 [
-                    -75,
-                    -180
+                    -21.4756,
+                    -63.3725
                 ],
                 [
-                    81,
-                    180
+                    51.3121,
+                    55.9259
                 ]
             ],
-            "min_zoom": 2,
-            "max_zoom": 20,
-            "apikey": "choisirgeoportail",
+            "min_zoom": 0,
+            "max_zoom": 19,
             "format": "image/png",
             "style": "PCI vecteur",
             "variant": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS",
-            "name": "GeoportailFrance.parcels"
+            "name": "GeoportailFrance.parcels",
+            "TileMatrixSet": "PM"
         },
         "orthos": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\" href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
                 [
-                    -75,
-                    -180
+                    -89.0,
+                    -180.0
                 ],
                 [
-                    81,
-                    180
+                    89.0,
+                    180.0
                 ]
             ],
-            "min_zoom": 2,
-            "max_zoom": 19,
-            "apikey": "choisirgeoportail",
+            "min_zoom": 0,
+            "max_zoom": 20,
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS",
-            "name": "GeoportailFrance.orthos"
+            "name": "GeoportailFrance.orthos",
+            "TileMatrixSet": "PM"
         }
     },
     "OneMapSG": {

--- a/provider_sources/leaflet-providers-parsed.json
+++ b/provider_sources/leaflet-providers-parsed.json
@@ -2485,7 +2485,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-oslondon1k1893",
-            "name": "NLS.oslondon1k1893"
+            "name": "NLS.oslondon1k1893",
+            "apikey": "<insert your API key here>"
         }
     },
     "JusticeMap": {

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2958,7 +2958,7 @@
                 ]
             ],
             "min_zoom": 0,
-            "max_zoom": 20,
+            "max_zoom": 21,
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS",
@@ -8852,8 +8852,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2002",
             "name": "GeoportailFrance.Ocsge_Constructions_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8876,8 +8875,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2011",
             "name": "GeoportailFrance.Ocsge_Constructions_2011",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8900,8 +8898,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2014",
             "name": "GeoportailFrance.Ocsge_Constructions_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8924,8 +8921,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2016",
             "name": "GeoportailFrance.Ocsge_Constructions_2016",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9017,8 +9013,7 @@
             "variant": "OCSGE.COUVERTURE.2002",
             "name": "GeoportailFrance.Ocsge_Couverture_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9041,8 +9036,7 @@
             "variant": "OCSGE.COUVERTURE.2011",
             "name": "GeoportailFrance.Ocsge_Couverture_2011",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9065,8 +9059,7 @@
             "variant": "OCSGE.COUVERTURE.2014",
             "name": "GeoportailFrance.Ocsge_Couverture_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9089,8 +9082,7 @@
             "variant": "OCSGE.COUVERTURE.2016",
             "name": "GeoportailFrance.Ocsge_Couverture_2016",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9182,8 +9174,7 @@
             "variant": "OCSGE.USAGE.2002",
             "name": "GeoportailFrance.Ocsge_Usage_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9206,8 +9197,7 @@
             "variant": "OCSGE.USAGE.2011",
             "name": "GeoportailFrance.Ocsge_Usage_2011",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9230,8 +9220,7 @@
             "variant": "OCSGE.USAGE.2014",
             "name": "GeoportailFrance.Ocsge_Usage_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9254,8 +9243,7 @@
             "variant": "OCSGE.USAGE.2016",
             "name": "GeoportailFrance.Ocsge_Usage_2016",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11670,8 +11658,7 @@
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.COAST2000",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Coast2000",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Geneve": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11694,8 +11681,7 @@
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.GENEVE",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Geneve",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ilesdunord": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13052,8 +13038,7 @@
             "variant": "PCRS.LAMB93",
             "name": "GeoportailFrance.Pcrs_Lamb93",
             "TileMatrixSet": "LAMB93_5cm",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Points_Injection_Biomethane": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13076,8 +13061,7 @@
             "variant": "POINTS.INJECTION.BIOMETHANE",
             "name": "GeoportailFrance.Points_Injection_Biomethane",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here",
-            "status": "broken"
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Eolien_Reglementaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2910,7 +2910,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
             "name": "GeoportailFrance.plan",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "parcels": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -2932,7 +2933,8 @@
             "style": "PCI vecteur",
             "variant": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS",
             "name": "GeoportailFrance.parcels",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "orthos": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -2954,7 +2956,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS",
             "name": "GeoportailFrance.orthos",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Acces_Biomethane": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -2976,7 +2979,8 @@
             "style": "ACCES.BIOMETHANE",
             "variant": "ACCES.BIOMETHANE",
             "name": "GeoportailFrance.Acces_Biomethane",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Adminexpress_cog_carto_Latest": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -2998,7 +3002,8 @@
             "style": "normal",
             "variant": "ADMINEXPRESS-COG-CARTO.LATEST",
             "name": "GeoportailFrance.Adminexpress_cog_carto_Latest",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Adminexpress_cog_Latest": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3020,7 +3025,8 @@
             "style": "normal",
             "variant": "ADMINEXPRESS-COG.LATEST",
             "name": "GeoportailFrance.Adminexpress_cog_Latest",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Adminexpress_2023_11_15": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3042,7 +3048,8 @@
             "style": "normal",
             "variant": "ADMINEXPRESS_2023-11-15",
             "name": "GeoportailFrance.Adminexpress_2023_11_15",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Adminexpress_cog_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3064,7 +3071,8 @@
             "style": "normal",
             "variant": "ADMINEXPRESS_COG_2020",
             "name": "GeoportailFrance.Adminexpress_cog_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Areamanagement_Zfu": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3086,7 +3094,8 @@
             "style": "normal",
             "variant": "AREAMANAGEMENT.ZFU",
             "name": "GeoportailFrance.Areamanagement_Zfu",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Areamanagement_Zus": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3108,7 +3117,8 @@
             "style": "normal",
             "variant": "AREAMANAGEMENT.ZUS",
             "name": "GeoportailFrance.Areamanagement_Zus",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Aire_parcellaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3130,7 +3140,8 @@
             "style": "normal",
             "variant": "Aire-Parcellaire",
             "name": "GeoportailFrance.Aire_parcellaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Bdcarto_etat_major_Niveau3": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3152,7 +3163,8 @@
             "style": "normal",
             "variant": "BDCARTO_ETAT-MAJOR.NIVEAU3",
             "name": "GeoportailFrance.Bdcarto_etat_major_Niveau3",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Bdcarto_etat_major_Niveau4": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3174,7 +3186,8 @@
             "style": "normal",
             "variant": "BDCARTO_ETAT-MAJOR.NIVEAU4",
             "name": "GeoportailFrance.Bdcarto_etat_major_Niveau4",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Besoin_Chaleur_Industriel": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3196,7 +3209,8 @@
             "style": "BESOIN.CHALEUR.INDUSTRIEL",
             "variant": "BESOIN.CHALEUR.INDUSTRIEL",
             "name": "GeoportailFrance.Besoin_Chaleur_Industriel",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Besoin_Chaleur_Residentiel": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3218,7 +3232,8 @@
             "style": "BESOIN.CHALEUR.RESIDENTIEL",
             "variant": "BESOIN.CHALEUR.RESIDENTIEL",
             "name": "GeoportailFrance.Besoin_Chaleur_Residentiel",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Besoin_Chaleur_Tertiaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3240,7 +3255,8 @@
             "style": "BESOIN.CHALEUR.TERTIAIRE",
             "variant": "BESOIN.CHALEUR.TERTIAIRE",
             "name": "GeoportailFrance.Besoin_Chaleur_Tertiaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Besoin_Froid_Residentiel": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3262,7 +3278,8 @@
             "style": "BESOIN.FROID.RESIDENTIEL",
             "variant": "BESOIN.FROID.RESIDENTIEL",
             "name": "GeoportailFrance.Besoin_Froid_Residentiel",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Besoin_Froid_Tertiaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3284,7 +3301,8 @@
             "style": "BESOIN.FROID.TERTIAIRE",
             "variant": "BESOIN.FROID.TERTIAIRE",
             "name": "GeoportailFrance.Besoin_Froid_Tertiaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Buildings_Buildings": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3306,7 +3324,8 @@
             "style": "BUILDINGS.BUILDINGS",
             "variant": "BUILDINGS.BUILDINGS",
             "name": "GeoportailFrance.Buildings_Buildings",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cadastral_Parcels_Sections": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3328,7 +3347,8 @@
             "style": "normal",
             "variant": "CADASTRAL.PARCELS.SECTIONS",
             "name": "GeoportailFrance.Cadastral_Parcels_Sections",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cadastralparcels_Heatmap": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3350,7 +3370,8 @@
             "style": "DECALAGE DE LA REPRESENTATION CADASTRALE",
             "variant": "CADASTRALPARCELS.HEATMAP",
             "name": "GeoportailFrance.Cadastralparcels_Heatmap",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cadastralparcels_Histo_2008_2013_Parcels": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3372,7 +3393,8 @@
             "style": "bdparcellaire",
             "variant": "CADASTRALPARCELS.HISTO.2008-2013.PARCELS",
             "name": "GeoportailFrance.Cadastralparcels_Histo_2008_2013_Parcels",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cadastralparcels_Parcels": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3394,7 +3416,8 @@
             "style": "normal",
             "variant": "CADASTRALPARCELS.PARCELS",
             "name": "GeoportailFrance.Cadastralparcels_Parcels",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cadastralparcels_Qualrefbdp": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3416,7 +3439,8 @@
             "style": "DIVCAD_MTD",
             "variant": "CADASTRALPARCELS.QUALREFBDP",
             "name": "GeoportailFrance.Cadastralparcels_Qualrefbdp",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cadastres_Solaires_Locaux": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3438,7 +3462,8 @@
             "style": "CADASTRES.SOLAIRES.LOCAUX",
             "variant": "CADASTRES.SOLAIRES.LOCAUX",
             "name": "GeoportailFrance.Cadastres_Solaires_Locaux",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Capacite_Accueil_Electrique": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3460,7 +3485,8 @@
             "style": "CAPACITE.ACCUEIL.ELECTRIQUE",
             "variant": "CAPACITE.ACCUEIL.ELECTRIQUE",
             "name": "GeoportailFrance.Capacite_Accueil_Electrique",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cartes_14_18_edugeo_pyr_png_fxx_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3482,7 +3508,8 @@
             "style": "normal",
             "variant": "CARTES-14-18-EDUGEO_PYR-PNG_FXX_WM",
             "name": "GeoportailFrance.Cartes_14_18_edugeo_pyr_png_fxx_wm",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cartes_Naturalearth": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3504,7 +3531,8 @@
             "style": "normal",
             "variant": "CARTES.NATURALEARTH",
             "name": "GeoportailFrance.Cartes_Naturalearth",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Cget_qp_bdd_wld_wm_wmts_20150914": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3526,7 +3554,8 @@
             "style": "normal",
             "variant": "CGET_QP_BDD_WLD_WM_WMTS_20150914",
             "name": "GeoportailFrance.Cget_qp_bdd_wld_wm_wmts_20150914",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Communes_Prioritydisctrict": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3548,7 +3577,8 @@
             "style": "normal",
             "variant": "COMMUNES.PRIORITYDISCTRICT",
             "name": "GeoportailFrance.Communes_Prioritydisctrict",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Communes_Sismicite": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3570,7 +3600,8 @@
             "style": "normal",
             "variant": "COMMUNES.SISMICITE",
             "name": "GeoportailFrance.Communes_Sismicite",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Conso_Elec_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3592,7 +3623,8 @@
             "style": "CONSO.ELEC.COMMUNE",
             "variant": "CONSO.ELEC.COMMUNE",
             "name": "GeoportailFrance.Conso_Elec_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Conso_Gaz_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3614,7 +3646,8 @@
             "style": "CONSO.GAZ.COMMUNE",
             "variant": "CONSO.GAZ.COMMUNE",
             "name": "GeoportailFrance.Conso_Gaz_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Debroussaillement": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3636,7 +3669,8 @@
             "style": "nolegend",
             "variant": "DEBROUSSAILLEMENT",
             "name": "GeoportailFrance.Debroussaillement",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Delaisses_Autoroutiers": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3658,7 +3692,8 @@
             "style": "DELAISSES.AUTOROUTIERS",
             "variant": "DELAISSES.AUTOROUTIERS",
             "name": "GeoportailFrance.Delaisses_Autoroutiers",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Dreal_Zonage_pinel": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3680,7 +3715,8 @@
             "style": "normal",
             "variant": "DREAL.ZONAGE_PINEL",
             "name": "GeoportailFrance.Dreal_Zonage_pinel",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Edugeo_Landuse_Agriculture2012": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3702,7 +3738,8 @@
             "style": "normal",
             "variant": "EDUGEO.LANDUSE.AGRICULTURE2012",
             "name": "GeoportailFrance.Edugeo_Landuse_Agriculture2012",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Edugeo_Naturalriskzones_1910floodedwatersheds": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3724,7 +3761,8 @@
             "style": "normal",
             "variant": "EDUGEO.NATURALRISKZONES.1910FLOODEDWATERSHEDS",
             "name": "GeoportailFrance.Edugeo_Naturalriskzones_1910floodedwatersheds",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevation_Contour_Line": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3746,7 +3784,8 @@
             "style": "normal",
             "variant": "ELEVATION.CONTOUR.LINE",
             "name": "GeoportailFrance.Elevation_Contour_Line",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevation_Elevationgridcoverage_Shadow": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3768,7 +3807,8 @@
             "style": "estompage_grayscale",
             "variant": "ELEVATION.ELEVATIONGRIDCOVERAGE.SHADOW",
             "name": "GeoportailFrance.Elevation_Elevationgridcoverage_Shadow",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevation_Elevationgridcoverage_Threshold": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3790,7 +3830,8 @@
             "style": "ELEVATION.ELEVATIONGRIDCOVERAGE.THRESHOLD",
             "variant": "ELEVATION.ELEVATIONGRIDCOVERAGE.THRESHOLD",
             "name": "GeoportailFrance.Elevation_Elevationgridcoverage_Threshold",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevation_Level0": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3812,7 +3853,8 @@
             "style": "normal",
             "variant": "ELEVATION.LEVEL0",
             "name": "GeoportailFrance.Elevation_Level0",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevation_Slopes": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3834,7 +3876,8 @@
             "style": "normal",
             "variant": "ELEVATION.SLOPES",
             "name": "GeoportailFrance.Elevation_Slopes",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevation_Slopes_Highres": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3856,7 +3899,8 @@
             "style": "normal",
             "variant": "ELEVATION.SLOPES.HIGHRES",
             "name": "GeoportailFrance.Elevation_Slopes_Highres",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Elevationgridcoverage_Highres_Quality": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3878,7 +3922,8 @@
             "style": "Graphe de source du RGE Alti",
             "variant": "ELEVATIONGRIDCOVERAGE.HIGHRES.QUALITY",
             "name": "GeoportailFrance.Elevationgridcoverage_Highres_Quality",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Aero_Civil": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3900,7 +3945,8 @@
             "style": "ENR.AERO.CIVIL",
             "variant": "ENR.AERO.CIVIL",
             "name": "GeoportailFrance.Enr_Aero_Civil",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Aero_Militaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3922,7 +3968,8 @@
             "style": "ENR.AERO.MILITAIRE",
             "variant": "ENR.AERO.MILITAIRE",
             "name": "GeoportailFrance.Enr_Aero_Militaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Grands_Sites_France": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3944,7 +3991,8 @@
             "style": "ENR.GRANDS.SITES.FRANCE",
             "variant": "ENR.GRANDS.SITES.FRANCE",
             "name": "GeoportailFrance.Enr_Grands_Sites_France",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Perimetre_Habitation": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3966,7 +4014,8 @@
             "style": "PERIMETRE.HABITATION",
             "variant": "ENR.PERIMETRE.HABITATION",
             "name": "GeoportailFrance.Enr_Perimetre_Habitation",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Perimetre_Pente": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -3988,7 +4037,8 @@
             "style": "PERIMETRE.PENTE",
             "variant": "ENR.PERIMETRE.PENTE",
             "name": "GeoportailFrance.Enr_Perimetre_Pente",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Perimetre_Route": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4010,7 +4060,8 @@
             "style": "PERIMETRE.ROUTE",
             "variant": "ENR.PERIMETRE.ROUTE",
             "name": "GeoportailFrance.Enr_Perimetre_Route",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enr_Perimetre_Voie_Ferree": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4032,7 +4083,8 @@
             "style": "PERIMETRE.VOIE.FERREE",
             "variant": "ENR.PERIMETRE.VOIE.FERREE",
             "name": "GeoportailFrance.Enr_Perimetre_Voie_Ferree",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Besoins_Chaud": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4054,7 +4106,8 @@
             "style": "ENREZO.BESOINS.CHAUD",
             "variant": "ENREZO.BESOINS.CHAUD",
             "name": "GeoportailFrance.Enrezo_Besoins_Chaud",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Besoins_Froid": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4076,7 +4129,8 @@
             "style": "ENREZO.BESOINS.FROID",
             "variant": "ENREZO.BESOINS.FROID",
             "name": "GeoportailFrance.Enrezo_Besoins_Froid",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Chaleur_Fatale_500_Industries": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4098,7 +4152,8 @@
             "style": "ENREZO.CHALEUR.FATALE.500.INDUSTRIES",
             "variant": "ENREZO.CHALEUR.FATALE.500.INDUSTRIES",
             "name": "GeoportailFrance.Enrezo_Chaleur_Fatale_500_Industries",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Chaleur_Fatale_Datacenter": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4120,7 +4175,8 @@
             "style": "ENREZO.CHALEUR.FATALE.DATACENTER",
             "variant": "ENREZO.CHALEUR.FATALE.DATACENTER",
             "name": "GeoportailFrance.Enrezo_Chaleur_Fatale_Datacenter",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Chaleur_Fatale_Step": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4142,7 +4198,8 @@
             "style": "ENREZO.CHALEUR.FATALE.STEP",
             "variant": "ENREZO.CHALEUR.FATALE.STEP",
             "name": "GeoportailFrance.Enrezo_Chaleur_Fatale_Step",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Zone_Potentiel_Chaud": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4164,7 +4221,8 @@
             "style": "ENREZO.ZONE.POTENTIEL.CHAUD",
             "variant": "ENREZO.ZONE.POTENTIEL.CHAUD",
             "name": "GeoportailFrance.Enrezo_Zone_Potentiel_Chaud",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Zone_Potentiel_Fort_Chaud": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4186,7 +4244,8 @@
             "style": "ENREZO.ZONE.POTENTIEL.FORT.CHAUD",
             "variant": "ENREZO.ZONE.POTENTIEL.FORT.CHAUD",
             "name": "GeoportailFrance.Enrezo_Zone_Potentiel_Fort_Chaud",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Zone_Potentiel_Fort_Froid": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4208,7 +4267,8 @@
             "style": "ENREZO.ZONE.POTENTIEL.FORT.FROID",
             "variant": "ENREZO.ZONE.POTENTIEL.FORT.FROID",
             "name": "GeoportailFrance.Enrezo_Zone_Potentiel_Fort_Froid",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Enrezo_Zone_Potentiel_Froid": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4230,7 +4290,8 @@
             "style": "ENREZO.ZONE.POTENTIEL.FROID",
             "variant": "ENREZO.ZONE.POTENTIEL.FROID",
             "name": "GeoportailFrance.Enrezo_Zone_Potentiel_Froid",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Evol_surface_forestiere_1980_2011_edugeo_pyr_png_fxx_lamb93_20150918": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4252,7 +4313,8 @@
             "style": "normal",
             "variant": "EVOL-SURFACE-FORESTIERE-1980-2011_EDUGEO_PYR-PNG_FXX_LAMB93_20150918",
             "name": "GeoportailFrance.Evol_surface_forestiere_1980_2011_edugeo_pyr_png_fxx_lamb93_20150918",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Forets_Publiques": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4274,7 +4336,8 @@
             "style": "FORETS PUBLIQUES ONF",
             "variant": "FORETS.PUBLIQUES",
             "name": "GeoportailFrance.Forets_Publiques",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Gaz_Corridor_Distribution": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4296,7 +4359,8 @@
             "style": "GAZ.CORRIDOR.DISTRIBUTION",
             "variant": "GAZ.CORRIDOR.DISTRIBUTION",
             "name": "GeoportailFrance.Gaz_Corridor_Distribution",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Gaz_Corridor_Transport": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4318,7 +4382,8 @@
             "style": "GAZ.CORRIDOR.TRANSPORT",
             "variant": "GAZ.CORRIDOR.TRANSPORT",
             "name": "GeoportailFrance.Gaz_Corridor_Transport",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Gaz_Reseau_Distribution": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4340,7 +4405,8 @@
             "style": "GAZ.RESEAU.DISTRIBUTION",
             "variant": "GAZ.RESEAU.DISTRIBUTION",
             "name": "GeoportailFrance.Gaz_Reseau_Distribution",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Gaz_Reseau_Transport": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4362,7 +4428,8 @@
             "style": "GAZ.RESEAU.TRANSPORT",
             "variant": "GAZ.RESEAU.TRANSPORT",
             "name": "GeoportailFrance.Gaz_Reseau_Transport",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystem_Dfci": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4384,7 +4451,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEM.DFCI",
             "name": "GeoportailFrance.Geographicalgridsystem_Dfci",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_1900typemaps": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4406,7 +4474,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.1900TYPEMAPS",
             "name": "GeoportailFrance.Geographicalgridsystems_1900typemaps",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_1914_11_15_arras_verdun_belfort_fronts_600k": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4428,7 +4497,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.1914_11_15_ARRAS_VERDUN_BELFORT_fronts_600K",
             "name": "GeoportailFrance.Geographicalgridsystems_1914_11_15_arras_verdun_belfort_fronts_600k",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Bonne": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4450,7 +4520,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.BONNE",
             "name": "GeoportailFrance.Geographicalgridsystems_Bonne",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Coastalmaps": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4472,7 +4543,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.COASTALMAPS",
             "name": "GeoportailFrance.Geographicalgridsystems_Coastalmaps",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Douaumont_fort_positions_5k_18mai1916": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4494,7 +4566,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.DOUAUMONT_FORT_positions_5K_18mai1916",
             "name": "GeoportailFrance.Geographicalgridsystems_Douaumont_fort_positions_5k_18mai1916",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Ajaccio1976": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4516,7 +4589,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.AJACCIO1976",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Ajaccio1976",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Belfort_montbelliard1973": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4538,7 +4612,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BELFORT-MONTBELLIARD1973",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Belfort_montbelliard1973",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Berry_sud1952": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4560,7 +4635,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BERRY-SUD1952",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Berry_sud1952",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Bethune1956": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4582,7 +4658,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BETHUNE1956",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Bethune1956",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Biarritz1979": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4604,7 +4681,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BIARRITZ1979",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Biarritz1979",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Bourg_st_maurice1974": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4626,7 +4704,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BOURG-ST-MAURICE1974",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Bourg_st_maurice1974",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Caen1969": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4648,7 +4727,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CAEN1969",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Caen1969",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Cap_dagde1971": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4670,7 +4750,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CAP-DAGDE1971",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Cap_dagde1971",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Clermont_ferrand1966": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4692,7 +4773,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CLERMONT-FERRAND1966",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Clermont_ferrand1966",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Creil_sud_picardie1979": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4714,7 +4796,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CREIL-SUD-PICARDIE1979",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Creil_sud_picardie1979",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Dijon1962": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4736,7 +4819,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.DIJON1962",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Dijon1962",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Douaumont1916": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4758,7 +4842,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.Douaumont1916",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Douaumont1916",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Grenoble1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4780,7 +4865,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GRENOBLE1965",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Grenoble1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Grenoble1976": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4802,7 +4888,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GRENOBLE1976",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Grenoble1976",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Grenoble1991": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4824,7 +4911,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GRENOBLE1991",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Grenoble1991",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Guadeloupe1955": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4846,7 +4934,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GUADELOUPE1955",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Guadeloupe1955",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Guyane1958": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4868,7 +4957,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GUYANE1958",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Guyane1958",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_La_reunion1980": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4890,7 +4980,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LA-REUNION1980",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_La_reunion1980",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_La_rochelle_rochefort1959": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4912,7 +5003,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LA-ROCHELLE-ROCHEFORT1959",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_La_rochelle_rochefort1959",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Le_havre1975": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4934,7 +5026,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LE-HAVRE1975",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Le_havre1975",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Le_havre1979": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4956,7 +5049,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LE-HAVRE1979",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Le_havre1979",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Limoges1966": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -4978,7 +5072,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LIMOGES1966",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Limoges1966",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Lyon1947": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5000,7 +5095,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1947",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Lyon1947",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Lyon1980": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5022,7 +5118,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1980",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Lyon1980",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Lyon1985": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5044,7 +5141,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1985",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Lyon1985",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Le_mort_homme_et_ses_environs_avril_1916": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5066,7 +5164,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.Le-Mort-Homme-et-ses-environs-avril-1916",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Le_mort_homme_et_ses_environs_avril_1916",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Marne_la_vallee1966": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5088,7 +5187,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARNE-LA-VALLEE1966",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Marne_la_vallee1966",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Marne_la_vallee1978": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5110,7 +5210,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARNE-LA-VALLEE1978",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Marne_la_vallee1978",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Marne_la_vallee1987": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5132,7 +5233,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARNE-LA-VALLEE1987",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Marne_la_vallee1987",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Marseille_martigues1947": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5154,7 +5256,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARSEILLE-MARTIGUES1947",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Marseille_martigues1947",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Marseille_martigues1980": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5176,7 +5279,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARSEILLE-MARTIGUES1980",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Marseille_martigues1980",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Marseille_martigues1986": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5198,7 +5302,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARSEILLE-MARTIGUES1986",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Marseille_martigues1986",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Metz_nancy1983": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5220,7 +5325,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.METZ-NANCY1983",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Metz_nancy1983",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Nantes1972": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5242,7 +5348,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.NANTES1972",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Nantes1972",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Paris1964": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5264,7 +5371,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.PARIS1964",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Paris1964",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Paris1979": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5286,7 +5394,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.PARIS1979",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Paris1979",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Positions_20k_avr1916": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5308,7 +5417,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.Positions_20K_avr1916",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Positions_20k_avr1916",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Reims1974": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5330,7 +5440,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.REIMS1974",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Reims1974",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Roissy1973": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5352,7 +5463,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.ROISSY1973",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Roissy1973",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Roissy1978": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5374,7 +5486,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.ROISSY1978",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Roissy1978",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Strasbourg1956": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5396,7 +5509,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.STRASBOURG1956",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Strasbourg1956",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Strasbourg1978": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5418,7 +5532,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.STRASBOURG1978",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Strasbourg1978",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Toulon_hyeres1976": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5440,7 +5555,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.TOULON-HYERES1976",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Toulon_hyeres1976",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Toulouse1948": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5462,7 +5578,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.TOULOUSE1948",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Toulouse1948",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Vannes_golfe_du_morbihan1960": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5484,7 +5601,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VANNES-GOLFE-DU-MORBIHAN1960",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Vannes_golfe_du_morbihan1960",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Vannes_golfe_du_morbihan1971": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5506,7 +5624,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VANNES-GOLFE-DU-MORBIHAN1971",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Vannes_golfe_du_morbihan1971",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Verdun_nord_fronts_francais_20k": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5528,7 +5647,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VERDUN_NORD_fronts_francais_20K",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Verdun_nord_fronts_francais_20k",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Verdun_nord_organisations_defensives_20k": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5550,7 +5670,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VERDUN_NORD_organisations_defensives_20K",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Verdun_nord_organisations_defensives_20k",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Edugeo_Versailles1979": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5572,7 +5693,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VERSAILLES1979",
             "name": "GeoportailFrance.Geographicalgridsystems_Edugeo_Versailles1979",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Etatmajor10": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5594,7 +5716,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10",
             "name": "GeoportailFrance.Geographicalgridsystems_Etatmajor10",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Etatmajor40": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5616,7 +5739,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR40",
             "name": "GeoportailFrance.Geographicalgridsystems_Etatmajor40",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Maps_Bduni_J1": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5638,7 +5762,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1",
             "name": "GeoportailFrance.Geographicalgridsystems_Maps_Bduni_J1",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Maps_Overview": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5660,7 +5785,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.MAPS.OVERVIEW",
             "name": "GeoportailFrance.Geographicalgridsystems_Maps_Overview",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Maps_Scan50_1950": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5682,7 +5808,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN50.1950",
             "name": "GeoportailFrance.Geographicalgridsystems_Maps_Scan50_1950",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Slopes_Mountain": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5704,7 +5831,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.SLOPES.MOUNTAIN",
             "name": "GeoportailFrance.Geographicalgridsystems_Slopes_Mountain",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Slopes_Pac": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5726,7 +5854,8 @@
             "style": "GEOGRAPHICALGRIDSYSTEMS.SLOPES.PAC",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.SLOPES.PAC",
             "name": "GeoportailFrance.Geographicalgridsystems_Slopes_Pac",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Terrier_v1": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5748,7 +5877,8 @@
             "style": "nolegend",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.TERRIER_V1",
             "name": "GeoportailFrance.Geographicalgridsystems_Terrier_v1",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Terrier_v2": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5770,7 +5900,8 @@
             "style": "nolegend",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.TERRIER_V2",
             "name": "GeoportailFrance.Geographicalgridsystems_Terrier_v2",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Verdun_environs_nord_fronts_offensves_50k": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5792,7 +5923,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.VERDUN_ENVIRONS_NORD_fronts_offensves_50K",
             "name": "GeoportailFrance.Geographicalgridsystems_Verdun_environs_nord_fronts_offensves_50k",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Verdun_environs_sud_nord_com_group_80k": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5814,7 +5946,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.VERDUN_ENVIRONS_SUD_NORD_com_group_80K",
             "name": "GeoportailFrance.Geographicalgridsystems_Verdun_environs_sud_nord_com_group_80k",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalgridsystems_Verdun_environs_fronts_50k_21_26fevr1916": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5836,7 +5969,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.VERDUN_ENVIRONS_fronts_50K_21-26fevr1916",
             "name": "GeoportailFrance.Geographicalgridsystems_Verdun_environs_fronts_50k_21_26fevr1916",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Geographicalnames_Names": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5858,7 +5992,8 @@
             "style": "normal",
             "variant": "GEOGRAPHICALNAMES.NAMES",
             "name": "GeoportailFrance.Geographicalnames_Names",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hr_Orthoimagery_Orthophotos": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5880,7 +6015,8 @@
             "style": "normal",
             "variant": "HR.ORTHOIMAGERY.ORTHOPHOTOS",
             "name": "GeoportailFrance.Hr_Orthoimagery_Orthophotos",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hydrography_Bcae_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5902,7 +6038,8 @@
             "style": "nolegend",
             "variant": "HYDROGRAPHY.BCAE.2020",
             "name": "GeoportailFrance.Hydrography_Bcae_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hydrography_Bcae_2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5924,7 +6061,8 @@
             "style": "nolegend",
             "variant": "HYDROGRAPHY.BCAE.2021",
             "name": "GeoportailFrance.Hydrography_Bcae_2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hydrography_Bcae_2022": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5946,7 +6084,8 @@
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.2022",
             "name": "GeoportailFrance.Hydrography_Bcae_2022",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hydrography_Bcae_2024": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5968,7 +6107,8 @@
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.2024",
             "name": "GeoportailFrance.Hydrography_Bcae_2024",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hydrography_Bcae_Latest": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -5990,7 +6130,8 @@
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.LATEST",
             "name": "GeoportailFrance.Hydrography_Bcae_Latest",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hydrography_Hydrography": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6012,7 +6153,8 @@
             "style": "normal",
             "variant": "HYDROGRAPHY.HYDROGRAPHY",
             "name": "GeoportailFrance.Hydrography_Hydrography",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Inpe": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6034,7 +6176,8 @@
             "style": "INPE",
             "variant": "INPE",
             "name": "GeoportailFrance.Inpe",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Enfants_0_17_Ans_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6056,7 +6199,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.ENFANTS.0.17.ANS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Enfants_0_17_Ans_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Logements_Surface_Moyenne_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6078,7 +6222,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.LOGEMENTS.SURFACE.MOYENNE.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Logements_Surface_Moyenne_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Niveau_De_Vie_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6100,7 +6245,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.NIVEAU.DE.VIE.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Niveau_De_Vie_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Familles_Monoparentales_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6122,7 +6268,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.FAMILLES.MONOPARENTALES.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Familles_Monoparentales_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Individus_25_39_Ans_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6144,7 +6291,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.INDIVIDUS.25.39.ANS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Individus_25_39_Ans_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Individus_40_54_Ans_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6166,7 +6314,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.INDIVIDUS.40.54.ANS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Individus_40_54_Ans_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Individus_55_64_Ans_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6188,7 +6337,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.INDIVIDUS.55.64.ANS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Individus_55_64_Ans_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Logements_Apres_1990_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6210,7 +6360,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.APRES.1990.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Logements_Apres_1990_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Logements_Avant_1945_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6232,7 +6383,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.AVANT.1945.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Logements_Avant_1945_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Logements_Collectifs_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6254,7 +6406,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.COLLECTIFS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Logements_Collectifs_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Logements_Construits_1945_1970_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6276,7 +6429,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.CONSTRUITS.1945.1970.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Logements_Construits_1945_1970_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Logements_Construits_1970_1990_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6298,7 +6452,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.CONSTRUITS.1970.1990.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Logements_Construits_1970_1990_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Logements_Sociaux_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6320,7 +6475,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.SOCIAUX.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Logements_Sociaux_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Menages_1_Personne_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6342,7 +6498,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.1.PERSONNE.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Menages_1_Personne_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Menages_5_Personnes_Ouplus_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6364,7 +6521,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.5.PERSONNES.OUPLUS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Menages_5_Personnes_Ouplus_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Menages_Maison_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6386,7 +6544,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.MAISON.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Menages_Maison_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Menages_Pauvres_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6408,7 +6567,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.PAUVRES.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Menages_Pauvres_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Menages_Proprietaires_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6430,7 +6590,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.PROPRIETAIRES.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Menages_Proprietaires_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Part_Plus_65_Ans_Secret": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6452,7 +6613,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.PLUS.65.ANS.SECRET",
             "name": "GeoportailFrance.Insee_Filosofi_Part_Plus_65_Ans_Secret",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Insee_Filosofi_Population": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6474,7 +6636,8 @@
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.POPULATION",
             "name": "GeoportailFrance.Insee_Filosofi_Population",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha00": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6496,7 +6659,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA00",
             "name": "GeoportailFrance.Landcover_Cha00",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha00_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6518,7 +6682,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA00_FR",
             "name": "GeoportailFrance.Landcover_Cha00_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha06": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6540,7 +6705,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA06",
             "name": "GeoportailFrance.Landcover_Cha06",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha06_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6562,7 +6728,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA06_DOM",
             "name": "GeoportailFrance.Landcover_Cha06_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha06_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6584,7 +6751,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA06_FR",
             "name": "GeoportailFrance.Landcover_Cha06_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha12": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6606,7 +6774,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA12",
             "name": "GeoportailFrance.Landcover_Cha12",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha12_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6628,7 +6797,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA12_DOM",
             "name": "GeoportailFrance.Landcover_Cha12_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha12_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6650,7 +6820,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA12_FR",
             "name": "GeoportailFrance.Landcover_Cha12_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha18": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6672,7 +6843,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.CHA18",
             "name": "GeoportailFrance.Landcover_Cha18",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha18_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6694,7 +6866,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA18_DOM",
             "name": "GeoportailFrance.Landcover_Cha18_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Cha18_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6716,7 +6889,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA18_FR",
             "name": "GeoportailFrance.Landcover_Cha18_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc00": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6738,7 +6912,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC00",
             "name": "GeoportailFrance.Landcover_Clc00",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc00r": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6760,7 +6935,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC00R",
             "name": "GeoportailFrance.Landcover_Clc00r",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc00r_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6782,7 +6958,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC00R_FR",
             "name": "GeoportailFrance.Landcover_Clc00r_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc00_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6804,7 +6981,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC00_DOM",
             "name": "GeoportailFrance.Landcover_Clc00_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc00_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6826,7 +7004,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC00_FR",
             "name": "GeoportailFrance.Landcover_Clc00_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc06": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6848,7 +7027,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06",
             "name": "GeoportailFrance.Landcover_Clc06",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc06r": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6870,7 +7050,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06R",
             "name": "GeoportailFrance.Landcover_Clc06r",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc06r_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6892,7 +7073,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06R_DOM",
             "name": "GeoportailFrance.Landcover_Clc06r_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc06r_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6914,7 +7096,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC06R_FR",
             "name": "GeoportailFrance.Landcover_Clc06r_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc06_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6936,7 +7119,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06_DOM",
             "name": "GeoportailFrance.Landcover_Clc06_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc06_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6958,7 +7142,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC06_FR",
             "name": "GeoportailFrance.Landcover_Clc06_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc12": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -6980,7 +7165,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC12",
             "name": "GeoportailFrance.Landcover_Clc12",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc12r": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7002,7 +7188,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.CLC12R",
             "name": "GeoportailFrance.Landcover_Clc12r",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc12r_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7024,7 +7211,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC12R_DOM",
             "name": "GeoportailFrance.Landcover_Clc12r_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc12r_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7046,7 +7234,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC12R_FR",
             "name": "GeoportailFrance.Landcover_Clc12r_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc12_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7068,7 +7257,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC12_DOM",
             "name": "GeoportailFrance.Landcover_Clc12_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc12_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7090,7 +7280,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC12_FR",
             "name": "GeoportailFrance.Landcover_Clc12_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc18": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7112,7 +7303,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.CLC18",
             "name": "GeoportailFrance.Landcover_Clc18",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc18_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7134,7 +7326,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC18_DOM",
             "name": "GeoportailFrance.Landcover_Clc18_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc18_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7156,7 +7349,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC18_FR",
             "name": "GeoportailFrance.Landcover_Clc18_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc90": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7178,7 +7372,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC90",
             "name": "GeoportailFrance.Landcover_Clc90",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Clc90_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7200,7 +7395,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC90_FR",
             "name": "GeoportailFrance.Landcover_Clc90_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Evol_surface_forestiere_1980_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7222,7 +7418,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.EVOL_SURFACE_FORESTIERE_1980-2011",
             "name": "GeoportailFrance.Landcover_Edugeo_Evol_surface_forestiere_1980_2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Klaus": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7244,7 +7441,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.KLAUS",
             "name": "GeoportailFrance.Landcover_Edugeo_Klaus",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Lgv_archeologie": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7266,7 +7464,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_archeologie",
             "name": "GeoportailFrance.Landcover_Edugeo_Lgv_archeologie",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Lgv_faune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7288,7 +7487,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_faune",
             "name": "GeoportailFrance.Landcover_Edugeo_Lgv_faune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Lgv_flore": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7310,7 +7510,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_flore",
             "name": "GeoportailFrance.Landcover_Edugeo_Lgv_flore",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Lgv_technique": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7332,7 +7533,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_technique",
             "name": "GeoportailFrance.Landcover_Edugeo_Lgv_technique",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Edugeo_Taux_boisement_2009_2013": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7354,7 +7556,8 @@
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.TAUX_BOISEMENT_2009-2013",
             "name": "GeoportailFrance.Landcover_Edugeo_Taux_boisement_2009_2013",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Forestareas": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7376,7 +7579,8 @@
             "style": "normal",
             "variant": "LANDCOVER.FORESTAREAS",
             "name": "GeoportailFrance.Landcover_Forestareas",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Forestinventory_V1": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7398,7 +7602,8 @@
             "style": "normal",
             "variant": "LANDCOVER.FORESTINVENTORY.V1",
             "name": "GeoportailFrance.Landcover_Forestinventory_V1",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Forestinventory_V2": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7420,7 +7625,8 @@
             "style": "LANDCOVER.FORESTINVENTORY.V2",
             "variant": "LANDCOVER.FORESTINVENTORY.V2",
             "name": "GeoportailFrance.Landcover_Forestinventory_V2",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc00": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7442,7 +7648,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC00",
             "name": "GeoportailFrance.Landcover_Grid_Clc00",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc00r_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7464,7 +7671,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC00R_FR",
             "name": "GeoportailFrance.Landcover_Grid_Clc00r_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc00_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7486,7 +7694,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC00_DOM",
             "name": "GeoportailFrance.Landcover_Grid_Clc00_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc00_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7508,7 +7717,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC00_FR",
             "name": "GeoportailFrance.Landcover_Grid_Clc00_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc06": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7530,7 +7740,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC06",
             "name": "GeoportailFrance.Landcover_Grid_Clc06",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc06r": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7552,7 +7763,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC06R",
             "name": "GeoportailFrance.Landcover_Grid_Clc06r",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc06r_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7574,7 +7786,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC06R_DOM",
             "name": "GeoportailFrance.Landcover_Grid_Clc06r_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc06r_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7596,7 +7809,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC06R_FR",
             "name": "GeoportailFrance.Landcover_Grid_Clc06r_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc06_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7618,7 +7832,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC06_DOM",
             "name": "GeoportailFrance.Landcover_Grid_Clc06_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc06_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7640,7 +7855,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC06_FR",
             "name": "GeoportailFrance.Landcover_Grid_Clc06_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc12": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7662,7 +7878,8 @@
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC12",
             "name": "GeoportailFrance.Landcover_Grid_Clc12",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc12_dom": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7684,7 +7901,8 @@
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC12_DOM",
             "name": "GeoportailFrance.Landcover_Grid_Clc12_dom",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc12_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7706,7 +7924,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC12_FR",
             "name": "GeoportailFrance.Landcover_Grid_Clc12_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Grid_Clc90_fr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7728,7 +7947,8 @@
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC90_FR",
             "name": "GeoportailFrance.Landcover_Grid_Clc90_fr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Dlt_Clc12": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7750,7 +7970,8 @@
             "style": "CORINE Land Cover - HR - type de for\u00eats",
             "variant": "LANDCOVER.HR.DLT.CLC12",
             "name": "GeoportailFrance.Landcover_Hr_Dlt_Clc12",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Dlt_Clc15": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7772,7 +7993,8 @@
             "style": "CORINE Land Cover - HR - type de for\u00eats",
             "variant": "LANDCOVER.HR.DLT.CLC15",
             "name": "GeoportailFrance.Landcover_Hr_Dlt_Clc15",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Gra_Clc15": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7794,7 +8016,8 @@
             "style": "CORINE Land Cover - HR - prairies",
             "variant": "LANDCOVER.HR.GRA.CLC15",
             "name": "GeoportailFrance.Landcover_Hr_Gra_Clc15",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Imd_Clc12": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7816,7 +8039,8 @@
             "style": "CORINE Land Cover - HR - taux d'imperm\u00e9abilisation des sols",
             "variant": "LANDCOVER.HR.IMD.CLC12",
             "name": "GeoportailFrance.Landcover_Hr_Imd_Clc12",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Imd_Clc15": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7838,7 +8062,8 @@
             "style": "CORINE Land Cover - HR - taux d'imperm\u00e9abilisation des sols",
             "variant": "LANDCOVER.HR.IMD.CLC15",
             "name": "GeoportailFrance.Landcover_Hr_Imd_Clc15",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Tcd_Clc12": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7860,7 +8085,8 @@
             "style": "CORINE Land Cover - HR - taux de couvert arbor\u00e9",
             "variant": "LANDCOVER.HR.TCD.CLC12",
             "name": "GeoportailFrance.Landcover_Hr_Tcd_Clc12",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Tcd_Clc15": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7882,7 +8108,8 @@
             "style": "CORINE Land Cover - HR - taux de couvert arbor\u00e9",
             "variant": "LANDCOVER.HR.TCD.CLC15",
             "name": "GeoportailFrance.Landcover_Hr_Tcd_Clc15",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Hr_Waw_Clc15": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7904,7 +8131,8 @@
             "style": "CORINE Land Cover - HR - zones humides et surfaces en eaux permanentes",
             "variant": "LANDCOVER.HR.WAW.CLC15",
             "name": "GeoportailFrance.Landcover_Hr_Waw_Clc15",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Sylvoecoregions": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7926,7 +8154,8 @@
             "style": "normal",
             "variant": "LANDCOVER.SYLVOECOREGIONS",
             "name": "GeoportailFrance.Landcover_Sylvoecoregions",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landcover_Sylvoecoregions_Alluvium": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7948,7 +8177,8 @@
             "style": "normal",
             "variant": "LANDCOVER.SYLVOECOREGIONS.ALLUVIUM",
             "name": "GeoportailFrance.Landcover_Sylvoecoregions_Alluvium",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture_Latest": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7970,7 +8200,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE.LATEST",
             "name": "GeoportailFrance.Landuse_Agriculture_Latest",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2007": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -7992,7 +8223,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2007",
             "name": "GeoportailFrance.Landuse_Agriculture2007",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2008": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8014,7 +8246,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2008",
             "name": "GeoportailFrance.Landuse_Agriculture2008",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2009": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8036,7 +8269,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2009",
             "name": "GeoportailFrance.Landuse_Agriculture2009",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8058,7 +8292,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2010",
             "name": "GeoportailFrance.Landuse_Agriculture2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8080,7 +8315,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2011",
             "name": "GeoportailFrance.Landuse_Agriculture2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2012": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8102,7 +8338,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2012",
             "name": "GeoportailFrance.Landuse_Agriculture2012",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2013": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8124,7 +8361,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2013",
             "name": "GeoportailFrance.Landuse_Agriculture2013",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8146,7 +8384,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2014",
             "name": "GeoportailFrance.Landuse_Agriculture2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2015": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8168,7 +8407,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2015",
             "name": "GeoportailFrance.Landuse_Agriculture2015",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8190,7 +8430,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2016",
             "name": "GeoportailFrance.Landuse_Agriculture2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8212,7 +8453,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2017",
             "name": "GeoportailFrance.Landuse_Agriculture2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8234,7 +8476,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2018",
             "name": "GeoportailFrance.Landuse_Agriculture2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8256,7 +8499,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2019",
             "name": "GeoportailFrance.Landuse_Agriculture2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8278,7 +8522,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2020",
             "name": "GeoportailFrance.Landuse_Agriculture2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8300,7 +8545,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2021",
             "name": "GeoportailFrance.Landuse_Agriculture2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Landuse_Agriculture2022": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8322,7 +8568,8 @@
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2022",
             "name": "GeoportailFrance.Landuse_Agriculture2022",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Lgv_edugeo_archeologie_pyr_png_fxx_wm_20170210": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8344,7 +8591,8 @@
             "style": "normal",
             "variant": "LGV_EDUGEO_ARCHEOLOGIE_PYR-PNG_FXX_WM_20170210",
             "name": "GeoportailFrance.Lgv_edugeo_archeologie_pyr_png_fxx_wm_20170210",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Lgv_edugeo_faune_pyr_png_fxx_wm_20170215": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8366,7 +8614,8 @@
             "style": "normal",
             "variant": "LGV_EDUGEO_FAUNE_PYR-PNG_FXX_WM_20170215",
             "name": "GeoportailFrance.Lgv_edugeo_faune_pyr_png_fxx_wm_20170215",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Lgv_edugeo_flore_pyr_png_fxx_wm_20170213": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8388,7 +8637,8 @@
             "style": "normal",
             "variant": "LGV_EDUGEO_FLORE_PYR-PNG_FXX_WM_20170213",
             "name": "GeoportailFrance.Lgv_edugeo_flore_pyr_png_fxx_wm_20170213",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Lgv_edugeo_technique_pyr_png_fxx_wm_20170215": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8410,7 +8660,8 @@
             "style": "normal",
             "variant": "LGV_EDUGEO_TECHNIQUE_PYR-PNG_FXX_WM_20170215",
             "name": "GeoportailFrance.Lgv_edugeo_technique_pyr_png_fxx_wm_20170215",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Limites_administratives_express_Latest": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8432,7 +8683,8 @@
             "style": "normal",
             "variant": "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
             "name": "GeoportailFrance.Limites_administratives_express_Latest",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Localisation_Mats_Eolien": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8454,7 +8706,8 @@
             "style": "LOCALISATION.MATS.EOLIEN",
             "variant": "LOCALISATION.MATS.EOLIEN",
             "name": "GeoportailFrance.Localisation_Mats_Eolien",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Lot_Chasse": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8476,7 +8729,8 @@
             "style": "normal",
             "variant": "LOT.CHASSE",
             "name": "GeoportailFrance.Lot_Chasse",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Lsep_crue_pyr_png_wld_wm_edugeo_20130128": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8498,7 +8752,8 @@
             "style": "normal",
             "variant": "LSEP-CRUE_PYR-PNG_WLD_WM_EDUGEO_20130128",
             "name": "GeoportailFrance.Lsep_crue_pyr_png_wld_wm_edugeo_20130128",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Naturalriskzones_1910floodedwatersheds": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8520,7 +8775,8 @@
             "style": "normal",
             "variant": "NATURALRISKZONES.1910FLOODEDWATERSHEDS",
             "name": "GeoportailFrance.Naturalriskzones_1910floodedwatersheds",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8542,7 +8798,8 @@
             "style": "normal",
             "variant": "OCSGE.CONSTRUCTIONS",
             "name": "GeoportailFrance.Ocsge_Constructions",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions_2002": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8565,6 +8822,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2002",
             "name": "GeoportailFrance.Ocsge_Constructions_2002",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Constructions_2011": {
@@ -8588,6 +8846,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2011",
             "name": "GeoportailFrance.Ocsge_Constructions_2011",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Constructions_2014": {
@@ -8611,6 +8870,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2014",
             "name": "GeoportailFrance.Ocsge_Constructions_2014",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Constructions_2016": {
@@ -8634,6 +8894,7 @@
             "variant": "OCSGE.CONSTRUCTIONS.2016",
             "name": "GeoportailFrance.Ocsge_Constructions_2016",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Constructions_2017": {
@@ -8656,7 +8917,8 @@
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2017",
             "name": "GeoportailFrance.Ocsge_Constructions_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Constructions_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8678,7 +8940,8 @@
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2019",
             "name": "GeoportailFrance.Ocsge_Constructions_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8700,7 +8963,8 @@
             "style": "normal",
             "variant": "OCSGE.COUVERTURE",
             "name": "GeoportailFrance.Ocsge_Couverture",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture_2002": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8723,6 +8987,7 @@
             "variant": "OCSGE.COUVERTURE.2002",
             "name": "GeoportailFrance.Ocsge_Couverture_2002",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Couverture_2011": {
@@ -8746,6 +9011,7 @@
             "variant": "OCSGE.COUVERTURE.2011",
             "name": "GeoportailFrance.Ocsge_Couverture_2011",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Couverture_2014": {
@@ -8769,6 +9035,7 @@
             "variant": "OCSGE.COUVERTURE.2014",
             "name": "GeoportailFrance.Ocsge_Couverture_2014",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Couverture_2016": {
@@ -8792,6 +9059,7 @@
             "variant": "OCSGE.COUVERTURE.2016",
             "name": "GeoportailFrance.Ocsge_Couverture_2016",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Couverture_2017": {
@@ -8814,7 +9082,8 @@
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2017",
             "name": "GeoportailFrance.Ocsge_Couverture_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Couverture_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8836,7 +9105,8 @@
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2019",
             "name": "GeoportailFrance.Ocsge_Couverture_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8858,7 +9128,8 @@
             "style": "normal",
             "variant": "OCSGE.USAGE",
             "name": "GeoportailFrance.Ocsge_Usage",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2002": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8880,7 +9151,8 @@
             "style": "normal",
             "variant": "OCSGE.USAGE.2002",
             "name": "GeoportailFrance.Ocsge_Usage_2002",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8903,6 +9175,7 @@
             "variant": "OCSGE.USAGE.2011",
             "name": "GeoportailFrance.Ocsge_Usage_2011",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Usage_2014": {
@@ -8925,7 +9198,8 @@
             "style": "normal",
             "variant": "OCSGE.USAGE.2014",
             "name": "GeoportailFrance.Ocsge_Usage_2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8948,6 +9222,7 @@
             "variant": "OCSGE.USAGE.2016",
             "name": "GeoportailFrance.Ocsge_Usage_2016",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Ocsge_Usage_2017": {
@@ -8970,7 +9245,8 @@
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2017",
             "name": "GeoportailFrance.Ocsge_Usage_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Usage_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8992,7 +9268,8 @@
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2019",
             "name": "GeoportailFrance.Ocsge_Usage_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Visu_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9014,7 +9291,8 @@
             "style": "nolegend",
             "variant": "OCSGE.VISU.2016",
             "name": "GeoportailFrance.Ocsge_Visu_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ocsge_Visu_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9036,7 +9314,8 @@
             "style": "nolegend",
             "variant": "OCSGE.VISU.2019",
             "name": "GeoportailFrance.Ocsge_Visu_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ofb_Zones_Exclues": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9058,7 +9337,8 @@
             "style": "OFB.ZONES.EXCLUES",
             "variant": "OFB.ZONES.EXCLUES",
             "name": "GeoportailFrance.Ofb_Zones_Exclues",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ofb_Zones_Necessitant_Avis_Gestionnaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9080,7 +9360,8 @@
             "style": "OFB.ZONES.NECESSITANT.AVIS.GESTIONNAIRE",
             "variant": "OFB.ZONES.NECESSITANT.AVIS.GESTIONNAIRE",
             "name": "GeoportailFrance.Ofb_Zones_Necessitant_Avis_Gestionnaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ortho_edugeo_pyr_png_wld_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9102,7 +9383,8 @@
             "style": "normal",
             "variant": "ORTHO-EDUGEO_PYR-PNG_WLD_WM",
             "name": "GeoportailFrance.Ortho_edugeo_pyr_png_wld_wm",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Ortho_express_2020_pyr_jpg_wld_wm_wmts2": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9124,7 +9406,8 @@
             "style": "normal",
             "variant": "ORTHO-EXPRESS-2020_PYR-JPG_WLD_WM_WMTS2",
             "name": "GeoportailFrance.Ortho_express_2020_pyr_jpg_wld_wm_wmts2",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Ajaccio1975": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9146,7 +9429,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.AJACCIO1975",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Ajaccio1975",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Ajaccio1990": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9168,7 +9452,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.AJACCIO1990",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Ajaccio1990",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Arcachon2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9190,7 +9475,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ARCACHON2010",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Arcachon2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Arras_lens_bethune2008": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9212,7 +9498,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ARRAS-LENS-BETHUNE2008",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Arras_lens_bethune2008",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Belfort_montbelliard1951": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9234,7 +9521,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BELFORT-MONTBELLIARD1951",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Belfort_montbelliard1951",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Berry_sud1950": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9256,7 +9544,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BERRY-SUD1950",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Berry_sud1950",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Berry_sud1970": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9278,7 +9567,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BERRY-SUD1970",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Berry_sud1970",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Bethune1963": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9300,7 +9590,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BETHUNE1963",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Bethune1963",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Bethune1964": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9322,7 +9613,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BETHUNE1964",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Bethune1964",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Bethune1988": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9344,7 +9636,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BETHUNE1988",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Bethune1988",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Biarritz1977": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9366,7 +9659,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BIARRITZ1977",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Biarritz1977",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Biarrtitz1979": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9388,7 +9682,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BIARRTITZ1979",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Biarrtitz1979",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Bordeaux2003": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9410,7 +9705,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BORDEAUX2003",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Bordeaux2003",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Bourg_st_maurice1956": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9432,7 +9728,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BOURG-ST-MAURICE1956",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Bourg_st_maurice1956",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Caen1991": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9454,7 +9751,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAEN1991",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Caen1991",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Cap_d_agde1968": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9476,7 +9774,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAP-D-AGDE1968",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Cap_d_agde1968",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Cap_d_agde2008": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9498,7 +9797,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAP-D-AGDE2008",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Cap_d_agde2008",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Cap_dage1981": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9520,7 +9820,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAP-DAGE1981",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Cap_dage1981",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Clermont_ferrand1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9542,7 +9843,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CLERMONT-FERRAND1965",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Clermont_ferrand1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Clermont_ferrand1985": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9564,7 +9866,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CLERMONT-FERRAND1985",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Clermont_ferrand1985",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Creil_sud_picardie1975": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9586,7 +9889,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CREIL-SUD-PICARDIE1975",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Creil_sud_picardie1975",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Dijon1971": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9608,7 +9912,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.DIJON1971",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Dijon1971",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Grenoble1966": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9630,7 +9935,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GRENOBLE1966",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Grenoble1966",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Grenoble1989": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9652,7 +9958,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GRENOBLE1989",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Grenoble1989",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Guadeloupe1984": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9674,7 +9981,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GUADELOUPE1984",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Guadeloupe1984",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Guyane1955": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9696,7 +10004,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GUYANE1955",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Guyane1955",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_La_reunion1961": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9718,7 +10027,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION1961",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_La_reunion1961",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_La_reunion1980": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9740,7 +10050,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION1980",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_La_reunion1980",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_La_reunion1989": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9762,7 +10073,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION1989",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_La_reunion1989",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_La_reunion2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9784,7 +10096,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION2010",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_La_reunion2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_La_rochelle_rochefort1973": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9806,7 +10119,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-ROCHELLE-ROCHEFORT1973",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_La_rochelle_rochefort1973",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Le_havre1955": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9828,7 +10142,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LE-HAVRE1955",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Le_havre1955",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Le_havre1964": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9850,7 +10165,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LE-HAVRE1964",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Le_havre1964",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Le_havre2008": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9872,7 +10188,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LE-HAVRE2008",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Le_havre2008",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Limoges1974": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9894,7 +10211,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LIMOGES1974",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Limoges1974",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Lyon1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9916,7 +10234,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON1965",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Lyon1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Lyon1984": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9938,7 +10257,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON1984",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Lyon1984",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Lyon1988": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9960,7 +10280,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON1988",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Lyon1988",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Lyon2008": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9982,7 +10303,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON2008",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Lyon2008",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marne_la_vallee1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10004,7 +10326,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARNE-LA-VALLEE1965",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marne_la_vallee1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marne_la_vallee1977": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10026,7 +10349,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARNE-LA-VALLEE1977",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marne_la_vallee1977",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marne_la_vallee1987": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10048,7 +10372,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARNE-LA-VALLEE1987",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marne_la_vallee1987",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1969": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10070,7 +10395,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1969",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marseille_martigues1969",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1980": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10092,7 +10418,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1980",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marseille_martigues1980",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1987": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10114,7 +10441,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1987",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marseille_martigues1987",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1988": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10136,7 +10464,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1988",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marseille_martigues1988",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Marseille_martigues2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10158,7 +10487,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES2010",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Marseille_martigues2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Martinique1988": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10180,7 +10510,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARTINIQUE1988",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Martinique1988",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Metz_nancy1982": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10202,7 +10533,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.METZ-NANCY1982",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Metz_nancy1982",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Nantes1971": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10224,7 +10556,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.NANTES1971",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Nantes1971",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Paris1949": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10246,7 +10579,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.PARIS1949",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Paris1949",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Paris1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10268,7 +10602,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.PARIS1965",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Paris1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Paris2010spot": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10290,7 +10625,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.PARIS2010SPOT",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Paris2010spot",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Reims1963": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10312,7 +10648,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS1963",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Reims1963",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Reims1973": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10334,7 +10671,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS1973",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Reims1973",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Reims1988": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10356,7 +10694,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS1988",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Reims1988",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Reims2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10378,7 +10717,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS2010",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Reims2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Roissy1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10400,7 +10740,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ROISSY1965",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Roissy1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Roissy1987": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10422,7 +10763,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ROISSY1987",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Roissy1987",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Strasbourg1975": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10444,7 +10786,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.STRASBOURG1975",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Strasbourg1975",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Strasbourg1985": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10466,7 +10809,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.STRASBOURG1985",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Strasbourg1985",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Strasbourg2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10488,7 +10832,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.STRASBOURG2010",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Strasbourg2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Toulon_hyeres1972": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10510,7 +10855,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.TOULON-HYERES1972",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Toulon_hyeres1972",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Toulouse1954": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10532,7 +10878,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.TOULOUSE1954",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Toulouse1954",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Valee_du_drac2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10554,7 +10901,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VALEE-DU-DRAC2010",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Valee_du_drac2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Vannes_golfe_du_morbihan1970": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10576,7 +10924,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VANNES-GOLFE-DU-MORBIHAN1970",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Vannes_golfe_du_morbihan1970",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Versailles1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10598,7 +10947,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VERSAILLES1965",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Versailles1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Edugeo_Versailles1989": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10620,7 +10970,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VERSAILLES1989",
             "name": "GeoportailFrance.Orthoimagery_Edugeo_Versailles1989",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2012": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10642,7 +10993,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2012",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2012",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2013": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10664,7 +11016,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2013",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2013",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10686,7 +11039,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2014",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2015": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10708,7 +11062,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2015",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2015",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10730,7 +11085,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2016",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10752,7 +11108,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2017",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10774,7 +11131,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2018",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10796,7 +11154,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2019",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10818,7 +11177,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2020",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10840,7 +11200,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2021",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2022": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10862,7 +11223,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2022",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Pleiades_2022",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Rapideye_2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10884,7 +11246,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.RAPIDEYE.2010",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Rapideye_2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Rapideye_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10906,7 +11269,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.RAPIDEYE.2011",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Rapideye_2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2013": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10928,7 +11292,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2013",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2013",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10950,7 +11315,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2014",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2015": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10972,7 +11338,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2015",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2015",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -10994,7 +11361,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2016",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11016,7 +11384,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2017",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11038,7 +11407,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2018",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11060,7 +11430,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2019",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11082,7 +11453,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2020",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11104,7 +11476,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2021",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Ortho_sat_Spot_2023": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11126,7 +11499,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2023",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2023",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophos_Restrictedareas": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11148,7 +11522,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOS.RESTRICTEDAREAS",
             "name": "GeoportailFrance.Orthoimagery_Orthophos_Restrictedareas",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_1950_1965": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11170,7 +11545,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.1950-1965",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_1950_1965",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_1965_1980": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11192,7 +11568,8 @@
             "style": "BDORTHOHISTORIQUE",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.1965-1980",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_1965_1980",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_1980_1995": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11214,7 +11591,8 @@
             "style": "BDORTHOHISTORIQUE",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.1980-1995",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_1980_1995",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Bdortho": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11236,7 +11614,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Bdortho",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Coast2000": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11259,6 +11638,7 @@
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.COAST2000",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Coast2000",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Orthoimagery_Orthophotos_Geneve": {
@@ -11282,6 +11662,7 @@
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.GENEVE",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Geneve",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Orthoimagery_Orthophotos_Ilesdunord": {
@@ -11304,7 +11685,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ILESDUNORD",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ilesdunord",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11326,7 +11708,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_express_2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11348,7 +11731,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2018",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_express_2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_express_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11370,7 +11754,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2019",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_express_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_express_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11392,7 +11777,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2020",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_express_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_express_2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11414,7 +11800,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2021",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_express_2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_express_2023": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11436,7 +11823,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2023",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_express_2023",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2012": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11458,7 +11846,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2012",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2012",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2013": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11480,7 +11869,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2013",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2013",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11502,7 +11892,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2014",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2015": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11524,7 +11915,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2015",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2015",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11546,7 +11938,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2016",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11568,7 +11961,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2017",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11590,7 +11984,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2018",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11612,7 +12007,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2019",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Irc_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11634,7 +12030,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2020",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Irc_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Low_res_Crs84": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11656,7 +12053,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.LOW_RES.CRS84",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Low_res_Crs84",
-            "TileMatrixSet": "WGS84G_PO"
+            "TileMatrixSet": "WGS84G_PO",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ncl": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11678,7 +12076,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.NCL",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ncl",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_asp_pac2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11700,7 +12099,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-ASP_PAC2020",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_asp_pac2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_asp_pac2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11722,7 +12122,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-ASP_PAC2021",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_asp_pac2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_asp_pac2022": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11744,7 +12145,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-ASP_PAC2022",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_asp_pac2022",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11766,7 +12168,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2017",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_express_2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11788,7 +12191,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2018",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_express_2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11810,7 +12214,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2019",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_express_2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11832,7 +12237,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2020",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_express_2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2021": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11854,7 +12260,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2021",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_express_2021",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2023": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11876,7 +12283,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2023",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Ortho_express_2023",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Pre_Irma": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11898,7 +12306,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.PRE.IRMA",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Pre_Irma",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Rapideye": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11920,7 +12329,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.RAPIDEYE",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Rapideye",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Socle_asp_2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11942,7 +12352,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.SOCLE-ASP.2018",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Socle_asp_2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Spot5": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11964,7 +12375,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.SPOT5",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Spot5",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos_Urgence_Alex": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11986,7 +12398,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.URGENCE.ALEX",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Urgence_Alex",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2000": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12008,7 +12421,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2000",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2000",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2000_2005": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12030,7 +12444,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2000-2005",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2000_2005",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2001": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12052,7 +12467,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2001",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2001",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2002": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12074,7 +12490,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2002",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2002",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2003": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12096,7 +12513,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2003",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2003",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2004": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12118,7 +12536,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2004",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2004",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2005": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12140,7 +12559,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2005",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2005",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2006": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12162,7 +12582,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2006",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2006",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2006_2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12184,7 +12605,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2006-2010",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2006_2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2007": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12206,7 +12628,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2007",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2007",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2008": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12228,7 +12651,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2008",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2008",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2009": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12250,7 +12674,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2009",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2009",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12272,7 +12697,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2010",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12294,7 +12720,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2011",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2011_2015": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12316,7 +12743,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2011-2015",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2011_2015",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2012": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12338,7 +12766,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2012",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2012",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2013": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12360,7 +12789,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2013",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2013",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12382,7 +12812,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2014",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2015": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12404,7 +12835,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2015",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2015",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12426,7 +12858,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2016",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12448,7 +12881,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2017",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2017",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2018": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12470,7 +12904,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2018",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2018",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2019": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12492,7 +12927,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2019",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2019",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Orthoimagery_Orthophotos2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12514,7 +12950,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2020",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos2020",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Parking_Sup_500": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12536,7 +12973,8 @@
             "style": "PARKING.SUP.500",
             "variant": "PARKING.SUP.500",
             "name": "GeoportailFrance.Parking_Sup_500",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Part_Enr_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12558,7 +12996,8 @@
             "style": "PART.ENR.COMMUNE",
             "variant": "PART.ENR.COMMUNE",
             "name": "GeoportailFrance.Part_Enr_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Pcrs_Lamb93": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12580,7 +13019,8 @@
             "style": "normal",
             "variant": "PCRS.LAMB93",
             "name": "GeoportailFrance.Pcrs_Lamb93",
-            "TileMatrixSet": "LAMB93_5cm"
+            "TileMatrixSet": "LAMB93_5cm",
+            "apikey": "your_api_key_here"
         },
         "Points_Injection_Biomethane": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12603,6 +13043,7 @@
             "variant": "POINTS.INJECTION.BIOMETHANE",
             "name": "GeoportailFrance.Points_Injection_Biomethane",
             "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here",
             "status": "broken"
         },
         "Potentiel_Eolien_Reglementaire": {
@@ -12625,7 +13066,8 @@
             "style": "POTENTIEL.EOLIEN.REGLE",
             "variant": "POTENTIEL.EOLIEN.REGLEMENTAIRE",
             "name": "GeoportailFrance.Potentiel_Eolien_Reglementaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Geothermie": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12647,7 +13089,8 @@
             "style": "POTENTIEL.GEOTHERMIE",
             "variant": "POTENTIEL.GEOTHERMIE",
             "name": "GeoportailFrance.Potentiel_Geothermie",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Hydro": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12669,7 +13112,8 @@
             "style": "POTENTIEL.HYDRO",
             "variant": "POTENTIEL.HYDRO",
             "name": "GeoportailFrance.Potentiel_Hydro",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Reseau_Chaleur_Paca": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12691,7 +13135,8 @@
             "style": "POTENTIEL.RESEAU.CHALEUR.PACA",
             "variant": "POTENTIEL.RESEAU.CHALEUR.PACA",
             "name": "GeoportailFrance.Potentiel_Reseau_Chaleur_Paca",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Reseau_Chaud_Froid_Paca": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12713,7 +13158,8 @@
             "style": "POTENTIEL.RESEAU.CHAUD.FROID.PACA",
             "variant": "POTENTIEL.RESEAU.CHAUD.FROID.PACA",
             "name": "GeoportailFrance.Potentiel_Reseau_Chaud_Froid_Paca",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Reseau_Froid_Paca": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12735,7 +13181,8 @@
             "style": "POTENTIEL.RESEAU.FROID.PACA",
             "variant": "POTENTIEL.RESEAU.FROID.PACA",
             "name": "GeoportailFrance.Potentiel_Reseau_Froid_Paca",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Solaire_Batiment": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12757,7 +13204,8 @@
             "style": "POTENTIEL.SOLAIRE.BATIMENT",
             "variant": "POTENTIEL.SOLAIRE.BATIMENT",
             "name": "GeoportailFrance.Potentiel_Solaire_Batiment",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Solaire_Friche": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12779,7 +13227,8 @@
             "style": "POTENTIEL.SOLAIRE.FRICHE",
             "variant": "POTENTIEL.SOLAIRE.FRICHE",
             "name": "GeoportailFrance.Potentiel_Solaire_Friche",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Solaire_Parking500": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12801,7 +13250,8 @@
             "style": "POTENTIEL.SOLAIRE.PARKING500",
             "variant": "POTENTIEL.SOLAIRE.PARKING500",
             "name": "GeoportailFrance.Potentiel_Solaire_Parking500",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Potentiel_Solaire_Sol": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12823,7 +13273,8 @@
             "style": "POTENTIEL.SOLAIRE.SOL",
             "variant": "POTENTIEL.SOLAIRE.SOL",
             "name": "GeoportailFrance.Potentiel_Solaire_Sol",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Prairies_Sensibles_Bcae": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12845,7 +13296,8 @@
             "style": "nolegend",
             "variant": "PRAIRIES.SENSIBLES.BCAE",
             "name": "GeoportailFrance.Prairies_Sensibles_Bcae",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Prod_Installation_Eolien": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12867,7 +13319,8 @@
             "style": "PROD.INSTALLATION.EOLIEN",
             "variant": "PROD.INSTALLATION.EOLIEN",
             "name": "GeoportailFrance.Prod_Installation_Eolien",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Prod_Installation_Hydro": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12889,7 +13342,8 @@
             "style": "PROD.INSTALLATION.HYDRO",
             "variant": "PROD.INSTALLATION.HYDRO",
             "name": "GeoportailFrance.Prod_Installation_Hydro",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Prod_Installation_Pv": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12911,7 +13365,8 @@
             "style": "PROD.INSTALLATION.PV",
             "variant": "PROD.INSTALLATION.PV",
             "name": "GeoportailFrance.Prod_Installation_Pv",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Productible_Biomethane_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12933,7 +13388,8 @@
             "style": "PRODUCTIBLE.BIOMETHANE.COMMUNE",
             "variant": "PRODUCTIBLE.BIOMETHANE.COMMUNE",
             "name": "GeoportailFrance.Productible_Biomethane_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Productible_Eolien_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12955,7 +13411,8 @@
             "style": "PRODUCTIBLE.EOLIEN.COMMUNE",
             "variant": "PRODUCTIBLE.EOLIEN.COMMUNE",
             "name": "GeoportailFrance.Productible_Eolien_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Productible_Methanisation_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12977,7 +13434,8 @@
             "style": "PRODUCTIBLE.METHANISATION.COMMUNE",
             "variant": "PRODUCTIBLE.METHANISATION.COMMUNE",
             "name": "GeoportailFrance.Productible_Methanisation_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Productible_Photovoltaique_Commune": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12999,7 +13457,8 @@
             "style": "PRODUCTIBLE.PHOTOVOLTAIQUE.COMMUNE",
             "variant": "PRODUCTIBLE.PHOTOVOLTAIQUE.COMMUNE",
             "name": "GeoportailFrance.Productible_Photovoltaique_Commune",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Apb": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13021,7 +13480,8 @@
             "style": "PROTECTEDAREAS.APB",
             "variant": "PROTECTEDAREAS.APB",
             "name": "GeoportailFrance.Protectedareas_Apb",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Apg": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13043,7 +13503,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.APG",
             "name": "GeoportailFrance.Protectedareas_Apg",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Aphn": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13065,7 +13526,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.APHN",
             "name": "GeoportailFrance.Protectedareas_Aphn",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Aplg": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13087,7 +13549,8 @@
             "style": "nolegend",
             "variant": "PROTECTEDAREAS.APLG",
             "name": "GeoportailFrance.Protectedareas_Aplg",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Bios": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13109,7 +13572,8 @@
             "style": "PROTECTEDAREAS.BIOS",
             "variant": "PROTECTEDAREAS.BIOS",
             "name": "GeoportailFrance.Protectedareas_Bios",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Gp": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13131,7 +13595,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.GP",
             "name": "GeoportailFrance.Protectedareas_Gp",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Inpg": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13153,7 +13618,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.INPG",
             "name": "GeoportailFrance.Protectedareas_Inpg",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Mnhn_Cdl_Parcels": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13175,7 +13641,8 @@
             "style": "PROTECTEDAREAS.MNHN.CDL.PARCELS",
             "variant": "PROTECTEDAREAS.MNHN.CDL.PARCELS",
             "name": "GeoportailFrance.Protectedareas_Mnhn_Cdl_Parcels",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Mnhn_Cdl_Perimeter": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13197,7 +13664,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.MNHN.CDL.PERIMETER",
             "name": "GeoportailFrance.Protectedareas_Mnhn_Cdl_Perimeter",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Mnhn_Conservatoires": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13219,7 +13687,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.MNHN.CONSERVATOIRES",
             "name": "GeoportailFrance.Protectedareas_Mnhn_Conservatoires",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Mnhn_Rn_Perimeter": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13241,7 +13710,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.MNHN.RN.PERIMETER",
             "name": "GeoportailFrance.Protectedareas_Mnhn_Rn_Perimeter",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Pn": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13263,7 +13733,8 @@
             "style": "PROTECTEDAREAS.PN",
             "variant": "PROTECTEDAREAS.PN",
             "name": "GeoportailFrance.Protectedareas_Pn",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Pnm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13285,7 +13756,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.PNM",
             "name": "GeoportailFrance.Protectedareas_Pnm",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Pnr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13307,7 +13779,8 @@
             "style": "PROTECTEDAREAS.PNR",
             "variant": "PROTECTEDAREAS.PNR",
             "name": "GeoportailFrance.Protectedareas_Pnr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Prsf": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13329,7 +13802,8 @@
             "style": "POINT RENCONTRE SECOURS FORET",
             "variant": "PROTECTEDAREAS.PRSF",
             "name": "GeoportailFrance.Protectedareas_Prsf",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Ramsar": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13351,7 +13825,8 @@
             "style": "PROTECTEDAREAS.RAMSAR",
             "variant": "PROTECTEDAREAS.RAMSAR",
             "name": "GeoportailFrance.Protectedareas_Ramsar",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Rb": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13373,7 +13848,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.RB",
             "name": "GeoportailFrance.Protectedareas_Rb",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Ripn": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13395,7 +13871,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.RIPN",
             "name": "GeoportailFrance.Protectedareas_Ripn",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Rn": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13417,7 +13894,8 @@
             "style": "PROTECTEDAREAS.RN",
             "variant": "PROTECTEDAREAS.RN",
             "name": "GeoportailFrance.Protectedareas_Rn",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Rnc": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13439,7 +13917,8 @@
             "style": "PROTECTEDAREAS.RNC",
             "variant": "PROTECTEDAREAS.RNC",
             "name": "GeoportailFrance.Protectedareas_Rnc",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Rncf": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13461,7 +13940,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.RNCF",
             "name": "GeoportailFrance.Protectedareas_Rncf",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Sic": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13483,7 +13963,8 @@
             "style": "PROTECTEDAREAS.SIC",
             "variant": "PROTECTEDAREAS.SIC",
             "name": "GeoportailFrance.Protectedareas_Sic",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Unesco": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13505,7 +13986,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.UNESCO",
             "name": "GeoportailFrance.Protectedareas_Unesco",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Znieff1": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13527,7 +14009,8 @@
             "style": "PROTECTEDAREAS.ZNIEFF1",
             "variant": "PROTECTEDAREAS.ZNIEFF1",
             "name": "GeoportailFrance.Protectedareas_Znieff1",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Znieff1_Sea": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13549,7 +14032,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.ZNIEFF1.SEA",
             "name": "GeoportailFrance.Protectedareas_Znieff1_Sea",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Znieff2": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13571,7 +14055,8 @@
             "style": "PROTECTEDAREAS.ZNIEFF2",
             "variant": "PROTECTEDAREAS.ZNIEFF2",
             "name": "GeoportailFrance.Protectedareas_Znieff2",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Znieff2_Sea": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13593,7 +14078,8 @@
             "style": "normal",
             "variant": "PROTECTEDAREAS.ZNIEFF2.SEA",
             "name": "GeoportailFrance.Protectedareas_Znieff2_Sea",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Zpr": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13615,7 +14101,8 @@
             "style": "PROTECTEDAREAS.BIOS",
             "variant": "PROTECTEDAREAS.ZPR",
             "name": "GeoportailFrance.Protectedareas_Zpr",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedareas_Zps": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13637,7 +14124,8 @@
             "style": "PROTECTEDAREAS.ZPS",
             "variant": "PROTECTEDAREAS.ZPS",
             "name": "GeoportailFrance.Protectedareas_Zps",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Protectedsites_Mnhn_Reserves_regionales": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13659,7 +14147,8 @@
             "style": "PROTECTEDSITES.MNHN.RESERVES-REGIONALES",
             "variant": "PROTECTEDSITES.MNHN.RESERVES-REGIONALES",
             "name": "GeoportailFrance.Protectedsites_Mnhn_Reserves_regionales",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Puissance_Installee_Biomethane": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13681,7 +14170,8 @@
             "style": "PUISSANCE.INSTALLEE.METHANISATION.BIOMETHANE",
             "variant": "PUISSANCE.INSTALLEE.BIOMETHANE",
             "name": "GeoportailFrance.Puissance_Installee_Biomethane",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Puissance_Installee_Methanisation": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13703,7 +14193,8 @@
             "style": "PUISSANCE.INSTALLEE.METHANISATION.BIOMETHANE",
             "variant": "PUISSANCE.INSTALLEE.METHANISATION",
             "name": "GeoportailFrance.Puissance_Installee_Methanisation",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Pva_ign_zone_marais_de_virvee_1945": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13725,7 +14216,8 @@
             "style": "BDORTHOHISTORIQUE",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1945",
             "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1945",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Pva_ign_zone_marais_de_virvee_1956": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13747,7 +14239,8 @@
             "style": "BDORTHOHISTORIQUE",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1956",
             "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1956",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Pva_ign_zone_marais_de_virvee_1976": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13769,7 +14262,8 @@
             "style": "normal",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1976",
             "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1976",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Pva_ign_zone_marais_de_virvee_1984": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13791,7 +14285,8 @@
             "style": "normal",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1984",
             "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1984",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Rapideye_pyr_jpeg_wld_wm_2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13813,7 +14308,8 @@
             "style": "normal",
             "variant": "RAPIDEYE_PYR-JPEG_WLD_WM_2010",
             "name": "GeoportailFrance.Rapideye_pyr_jpeg_wld_wm_2010",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Rapideye_pyr_jpeg_wld_wm_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13835,7 +14331,8 @@
             "style": "normal",
             "variant": "RAPIDEYE_PYR-JPEG_WLD_WM_2011",
             "name": "GeoportailFrance.Rapideye_pyr_jpeg_wld_wm_2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Repartition_Potentiel_Methanisation_2050": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13857,7 +14354,8 @@
             "style": "REPARTITION.POTENTIEL.METHANISATION.2050",
             "variant": "REPARTITION.POTENTIEL.METHANISATION.2050",
             "name": "GeoportailFrance.Repartition_Potentiel_Methanisation_2050",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Rpg2012_pyr_png_wld_edugeo_20170126": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13879,7 +14377,8 @@
             "style": "normal",
             "variant": "RPG2012_PYR-PNG_WLD_EDUGEO_20170126",
             "name": "GeoportailFrance.Rpg2012_pyr_png_wld_edugeo_20170126",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Scan_edugeo_pyr_png_fxx_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13901,7 +14400,8 @@
             "style": "normal",
             "variant": "SCAN-EDUGEO_PYR-PNG_FXX_WM",
             "name": "GeoportailFrance.Scan_edugeo_pyr_png_fxx_wm",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Scan1000_pyr_jpeg_wld_wm_wmts_3d": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13923,7 +14423,8 @@
             "style": "normal",
             "variant": "SCAN1000_PYR-JPEG_WLD_WM_WMTS_3D",
             "name": "GeoportailFrance.Scan1000_pyr_jpeg_wld_wm_wmts_3d",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_1te": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13945,7 +14446,8 @@
             "style": "RESEAU ROUTIER 1TE",
             "variant": "SECUROUTE.TE.1TE",
             "name": "GeoportailFrance.Securoute_Te_1te",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_2te48": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13967,7 +14469,8 @@
             "style": "RESEAU ROUTIER 2TE48",
             "variant": "SECUROUTE.TE.2TE48",
             "name": "GeoportailFrance.Securoute_Te_2te48",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_All": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13989,7 +14492,8 @@
             "style": "TOUS LES FRANCHISSEMENTS",
             "variant": "SECUROUTE.TE.ALL",
             "name": "GeoportailFrance.Securoute_Te_All",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_Oa": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14011,7 +14515,8 @@
             "style": "AUTRES FRANCHISSEMENTS",
             "variant": "SECUROUTE.TE.OA",
             "name": "GeoportailFrance.Securoute_Te_Oa",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_Pn": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14033,7 +14538,8 @@
             "style": "FRANCHISSEMENTS PASSAGE A NIVEAU",
             "variant": "SECUROUTE.TE.PN",
             "name": "GeoportailFrance.Securoute_Te_Pn",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_Pnd": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14055,7 +14561,8 @@
             "style": "FRANCHISSEMENTS PASSAGE A NIVEAU DIFFICILE",
             "variant": "SECUROUTE.TE.PND",
             "name": "GeoportailFrance.Securoute_Te_Pnd",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_Te120": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14077,7 +14584,8 @@
             "style": "RESEAU ROUTIER TE120",
             "variant": "SECUROUTE.TE.TE120",
             "name": "GeoportailFrance.Securoute_Te_Te120",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_Te72": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14099,7 +14607,8 @@
             "style": "RESEAU ROUTIER TE94",
             "variant": "SECUROUTE.TE.TE72",
             "name": "GeoportailFrance.Securoute_Te_Te72",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Securoute_Te_Te94": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14121,7 +14630,8 @@
             "style": "RESEAU ROUTIER TE94",
             "variant": "SECUROUTE.TE.TE94",
             "name": "GeoportailFrance.Securoute_Te_Te94",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Biogaz": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14143,7 +14653,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.BIOGAZ",
             "variant": "SITE.PRODUCTION.CHALEUR.BIOGAZ",
             "name": "GeoportailFrance.Site_Production_Chaleur_Biogaz",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Cogeneration": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14165,7 +14676,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.COGENERATION",
             "variant": "SITE.PRODUCTION.CHALEUR.COGENERATION",
             "name": "GeoportailFrance.Site_Production_Chaleur_Cogeneration",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Dechets": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14187,7 +14699,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.DECHETS",
             "variant": "SITE.PRODUCTION.CHALEUR.DECHETS",
             "name": "GeoportailFrance.Site_Production_Chaleur_Dechets",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Methanisaton": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14209,7 +14722,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.METHANISATON",
             "variant": "SITE.PRODUCTION.CHALEUR.METHANISATON",
             "name": "GeoportailFrance.Site_Production_Chaleur_Methanisaton",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Rc": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14231,7 +14745,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.RC",
             "variant": "SITE.PRODUCTION.CHALEUR.RC",
             "name": "GeoportailFrance.Site_Production_Chaleur_Rc",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Rc_Bretagne": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14253,7 +14768,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.RC.BRETAGNE",
             "variant": "SITE.PRODUCTION.CHALEUR.RC.BRETAGNE",
             "name": "GeoportailFrance.Site_Production_Chaleur_Rc_Bretagne",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Rc_Paca": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14275,7 +14791,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.RC.PACA",
             "variant": "SITE.PRODUCTION.CHALEUR.RC.PACA",
             "name": "GeoportailFrance.Site_Production_Chaleur_Rc_Paca",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Rcf_Lineaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14297,7 +14814,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.RCF.LINEAIRE",
             "variant": "SITE.PRODUCTION.CHALEUR.RCF.LINEAIRE",
             "name": "GeoportailFrance.Site_Production_Chaleur_Rcf_Lineaire",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Site_Production_Chaleur_Rcf_Point": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14319,7 +14837,8 @@
             "style": "SITE.PRODUCTION.CHALEUR.RCF.POINT",
             "variant": "SITE.PRODUCTION.CHALEUR.RCF.POINT",
             "name": "GeoportailFrance.Site_Production_Chaleur_Rcf_Point",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Spot_edugeo_pyr_png_wld_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14341,7 +14860,8 @@
             "style": "normal",
             "variant": "SPOT-EDUGEO_PYR-PNG_WLD_WM",
             "name": "GeoportailFrance.Spot_edugeo_pyr_png_wld_wm",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Spot5_pyr_jpeg_wld_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14363,7 +14883,8 @@
             "style": "normal",
             "variant": "SPOT5_PYR-JPEG_WLD_WM",
             "name": "GeoportailFrance.Spot5_pyr_jpeg_wld_wm",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Test_pbe_le_havre": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14385,7 +14906,8 @@
             "style": "normal",
             "variant": "TEST_PBE_LE_HAVRE",
             "name": "GeoportailFrance.Test_pbe_le_havre",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Thr_Orthoimagery_Orthophotos": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14407,7 +14929,8 @@
             "style": "normal",
             "variant": "THR.ORTHOIMAGERY.ORTHOPHOTOS",
             "name": "GeoportailFrance.Thr_Orthoimagery_Orthophotos",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Traces_Rando_Hivernale": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14429,7 +14952,8 @@
             "style": "normal",
             "variant": "TRACES.RANDO.HIVERNALE",
             "name": "GeoportailFrance.Traces_Rando_Hivernale",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transportnetwork_Commontransportelements_Markerpost": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14451,7 +14975,8 @@
             "style": "normal",
             "variant": "TRANSPORTNETWORK.COMMONTRANSPORTELEMENTS.MARKERPOST",
             "name": "GeoportailFrance.Transportnetwork_Commontransportelements_Markerpost",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transportnetwork_Commontransportelements_Markerpost_visu": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14473,7 +14998,8 @@
             "style": "normal",
             "variant": "TRANSPORTNETWORK.COMMONTRANSPORTELEMENTS.MARKERPOST_VISU",
             "name": "GeoportailFrance.Transportnetwork_Commontransportelements_Markerpost_visu",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transportnetworks_Railways": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14495,7 +15021,8 @@
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.RAILWAYS",
             "name": "GeoportailFrance.Transportnetworks_Railways",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transportnetworks_Roads": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14517,7 +15044,8 @@
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.ROADS",
             "name": "GeoportailFrance.Transportnetworks_Roads",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transportnetworks_Roads_Direction": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14539,7 +15067,8 @@
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.ROADS.DIRECTION",
             "name": "GeoportailFrance.Transportnetworks_Roads_Direction",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transportnetworks_Runways": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14561,7 +15090,8 @@
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.RUNWAYS",
             "name": "GeoportailFrance.Transportnetworks_Runways",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Transports_Drones_Restrictions": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14583,7 +15113,8 @@
             "style": "normal",
             "variant": "TRANSPORTS.DRONES.RESTRICTIONS",
             "name": "GeoportailFrance.Transports_Drones_Restrictions",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Utilityandgovernmentalservices_All": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14605,7 +15136,8 @@
             "style": "normal",
             "variant": "UTILITYANDGOVERNMENTALSERVICES.ALL",
             "name": "GeoportailFrance.Utilityandgovernmentalservices_All",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Zonage_Ofb": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14627,7 +15159,8 @@
             "style": "ZONAGE.OFB",
             "variant": "ZONAGE.OFB",
             "name": "GeoportailFrance.Zonage_Ofb",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Hedge_Hedge": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14649,7 +15182,8 @@
             "style": "normal",
             "variant": "hedge.hedge",
             "name": "GeoportailFrance.Hedge_Hedge",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         },
         "Tuto_scan1000_srd": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -14671,7 +15205,8 @@
             "style": "normal",
             "variant": "tuto_scan1000_SRD",
             "name": "GeoportailFrance.Tuto_scan1000_srd",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
         }
     },
     "OneMapSG": {

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -3035,29 +3035,6 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Adminexpress_2023_11_15": {
-            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
-            "attribution": "Geoportail France",
-            "bounds": [
-                [
-                    -21.4756,
-                    -63.3725
-                ],
-                [
-                    51.3121,
-                    55.9259
-                ]
-            ],
-            "min_zoom": 6,
-            "max_zoom": 16,
-            "format": "image/png",
-            "style": "normal",
-            "variant": "ADMINEXPRESS_2023-11-15",
-            "name": "GeoportailFrance.Adminexpress_2023_11_15",
-            "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
-        },
         "Adminexpress_cog_2020": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
@@ -3127,7 +3104,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Aire_parcellaire": {
+        "Aire-parcellaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -3146,7 +3123,7 @@
             "format": "image/png",
             "style": "normal",
             "variant": "Aire-Parcellaire",
-            "name": "GeoportailFrance.Aire_parcellaire",
+            "name": "GeoportailFrance.Aire-parcellaire",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -3495,7 +3472,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Cartes_14_18_edugeo_pyr_png_fxx_wm": {
+        "Cartes-14-18-edugeo_pyr-png_fxx_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -3514,7 +3491,7 @@
             "format": "image/png",
             "style": "normal",
             "variant": "CARTES-14-18-EDUGEO_PYR-PNG_FXX_WM",
-            "name": "GeoportailFrance.Cartes_14_18_edugeo_pyr_png_fxx_wm",
+            "name": "GeoportailFrance.Cartes-14-18-edugeo_pyr-png_fxx_wm",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -3653,6 +3630,29 @@
             "style": "CONSO.GAZ.COMMUNE",
             "variant": "CONSO.GAZ.COMMUNE",
             "name": "GeoportailFrance.Conso_Gaz_Commune",
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
+        },
+        "Cosia": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "attribution": "Geoportail France",
+            "bounds": [
+                [
+                    47.8392,
+                    -1.99328
+                ],
+                [
+                    48.3882,
+                    -1.42008
+                ]
+            ],
+            "min_zoom": 6,
+            "max_zoom": 18,
+            "format": "image/png",
+            "style": "normal",
+            "variant": "COSIA",
+            "name": "GeoportailFrance.Cosia",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -4300,7 +4300,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Evol_surface_forestiere_1980_2011_edugeo_pyr_png_fxx_lamb93_20150918": {
+        "Evol-surface-forestiere-1980-2011_edugeo_pyr-png_fxx_lamb93_20150918": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -4319,7 +4319,7 @@
             "format": "image/png",
             "style": "normal",
             "variant": "EVOL-SURFACE-FORESTIERE-1980-2011_EDUGEO_PYR-PNG_FXX_LAMB93_20150918",
-            "name": "GeoportailFrance.Evol_surface_forestiere_1980_2011_edugeo_pyr_png_fxx_lamb93_20150918",
+            "name": "GeoportailFrance.Evol-surface-forestiere-1980-2011_edugeo_pyr-png_fxx_lamb93_20150918",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -6091,6 +6091,29 @@
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.2022",
             "name": "GeoportailFrance.Hydrography_Bcae_2022",
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
+        },
+        "Hydrography_Bcae_2023": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "attribution": "Geoportail France",
+            "bounds": [
+                [
+                    41.3252,
+                    -5.15047
+                ],
+                [
+                    51.0991,
+                    9.57054
+                ]
+            ],
+            "min_zoom": 6,
+            "max_zoom": 17,
+            "format": "image/png",
+            "style": "normal",
+            "variant": "HYDROGRAPHY.BCAE.2023",
+            "name": "GeoportailFrance.Hydrography_Bcae_2023",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -8578,7 +8601,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Lgv_edugeo_archeologie_pyr_png_fxx_wm_20170210": {
+        "Lgv_edugeo_archeologie_pyr-png_fxx_wm_20170210": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -8597,11 +8620,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_ARCHEOLOGIE_PYR-PNG_FXX_WM_20170210",
-            "name": "GeoportailFrance.Lgv_edugeo_archeologie_pyr_png_fxx_wm_20170210",
+            "name": "GeoportailFrance.Lgv_edugeo_archeologie_pyr-png_fxx_wm_20170210",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Lgv_edugeo_faune_pyr_png_fxx_wm_20170215": {
+        "Lgv_edugeo_faune_pyr-png_fxx_wm_20170215": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -8620,11 +8643,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_FAUNE_PYR-PNG_FXX_WM_20170215",
-            "name": "GeoportailFrance.Lgv_edugeo_faune_pyr_png_fxx_wm_20170215",
+            "name": "GeoportailFrance.Lgv_edugeo_faune_pyr-png_fxx_wm_20170215",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Lgv_edugeo_flore_pyr_png_fxx_wm_20170213": {
+        "Lgv_edugeo_flore_pyr-png_fxx_wm_20170213": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -8643,11 +8666,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_FLORE_PYR-PNG_FXX_WM_20170213",
-            "name": "GeoportailFrance.Lgv_edugeo_flore_pyr_png_fxx_wm_20170213",
+            "name": "GeoportailFrance.Lgv_edugeo_flore_pyr-png_fxx_wm_20170213",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Lgv_edugeo_technique_pyr_png_fxx_wm_20170215": {
+        "Lgv_edugeo_technique_pyr-png_fxx_wm_20170215": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -8666,7 +8689,7 @@
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_TECHNIQUE_PYR-PNG_FXX_WM_20170215",
-            "name": "GeoportailFrance.Lgv_edugeo_technique_pyr_png_fxx_wm_20170215",
+            "name": "GeoportailFrance.Lgv_edugeo_technique_pyr-png_fxx_wm_20170215",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -8739,7 +8762,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Lsep_crue_pyr_png_wld_wm_edugeo_20130128": {
+        "Lsep-crue_pyr-png_wld_wm_edugeo_20130128": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -8758,7 +8781,7 @@
             "format": "image/png",
             "style": "normal",
             "variant": "LSEP-CRUE_PYR-PNG_WLD_WM_EDUGEO_20130128",
-            "name": "GeoportailFrance.Lsep_crue_pyr_png_wld_wm_edugeo_20130128",
+            "name": "GeoportailFrance.Lsep-crue_pyr-png_wld_wm_edugeo_20130128",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -9372,7 +9395,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Ortho_edugeo_pyr_png_wld_wm": {
+        "Ortho-edugeo_pyr-png_wld_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -9391,11 +9414,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHO-EDUGEO_PYR-PNG_WLD_WM",
-            "name": "GeoportailFrance.Ortho_edugeo_pyr_png_wld_wm",
+            "name": "GeoportailFrance.Ortho-edugeo_pyr-png_wld_wm",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Ortho_express_2020_pyr_jpg_wld_wm_wmts2": {
+        "Ortho-express-2020_pyr-jpg_wld_wm_wmts2": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -9414,7 +9437,7 @@
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHO-EXPRESS-2020_PYR-JPG_WLD_WM_WMTS2",
-            "name": "GeoportailFrance.Ortho_express_2020_pyr_jpg_wld_wm_wmts2",
+            "name": "GeoportailFrance.Ortho-express-2020_pyr-jpg_wld_wm_wmts2",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -11503,7 +11526,7 @@
                 ]
             ],
             "min_zoom": 0,
-            "max_zoom": 16,
+            "max_zoom": 17,
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2023",
@@ -14206,7 +14229,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Pva_ign_zone_marais_de_virvee_1945": {
+        "Pva_ign_zone-marais-de-virvee_1945": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14225,11 +14248,11 @@
             "format": "image/png",
             "style": "BDORTHOHISTORIQUE",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1945",
-            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1945",
+            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1945",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Pva_ign_zone_marais_de_virvee_1956": {
+        "Pva_ign_zone-marais-de-virvee_1956": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14248,11 +14271,11 @@
             "format": "image/png",
             "style": "BDORTHOHISTORIQUE",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1956",
-            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1956",
+            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1956",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Pva_ign_zone_marais_de_virvee_1976": {
+        "Pva_ign_zone-marais-de-virvee_1976": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14271,11 +14294,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1976",
-            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1976",
+            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1976",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Pva_ign_zone_marais_de_virvee_1984": {
+        "Pva_ign_zone-marais-de-virvee_1984": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14294,11 +14317,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1984",
-            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1984",
+            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1984",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Rapideye_pyr_jpeg_wld_wm_2010": {
+        "Rapideye_pyr-jpeg_wld_wm_2010": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14317,11 +14340,11 @@
             "format": "image/jpeg",
             "style": "normal",
             "variant": "RAPIDEYE_PYR-JPEG_WLD_WM_2010",
-            "name": "GeoportailFrance.Rapideye_pyr_jpeg_wld_wm_2010",
+            "name": "GeoportailFrance.Rapideye_pyr-jpeg_wld_wm_2010",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Rapideye_pyr_jpeg_wld_wm_2011": {
+        "Rapideye_pyr-jpeg_wld_wm_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14340,7 +14363,7 @@
             "format": "image/jpeg",
             "style": "normal",
             "variant": "RAPIDEYE_PYR-JPEG_WLD_WM_2011",
-            "name": "GeoportailFrance.Rapideye_pyr_jpeg_wld_wm_2011",
+            "name": "GeoportailFrance.Rapideye_pyr-jpeg_wld_wm_2011",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -14367,7 +14390,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Rpg2012_pyr_png_wld_edugeo_20170126": {
+        "Rpg2012_pyr-png_wld_edugeo_20170126": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14386,11 +14409,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "RPG2012_PYR-PNG_WLD_EDUGEO_20170126",
-            "name": "GeoportailFrance.Rpg2012_pyr_png_wld_edugeo_20170126",
+            "name": "GeoportailFrance.Rpg2012_pyr-png_wld_edugeo_20170126",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Scan_edugeo_pyr_png_fxx_wm": {
+        "Scan-edugeo_pyr-png_fxx_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14409,11 +14432,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "SCAN-EDUGEO_PYR-PNG_FXX_WM",
-            "name": "GeoportailFrance.Scan_edugeo_pyr_png_fxx_wm",
+            "name": "GeoportailFrance.Scan-edugeo_pyr-png_fxx_wm",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Scan1000_pyr_jpeg_wld_wm_wmts_3d": {
+        "Scan1000_pyr-jpeg_wld_wm_wmts_3d": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14432,7 +14455,7 @@
             "format": "image/jpeg",
             "style": "normal",
             "variant": "SCAN1000_PYR-JPEG_WLD_WM_WMTS_3D",
-            "name": "GeoportailFrance.Scan1000_pyr_jpeg_wld_wm_wmts_3d",
+            "name": "GeoportailFrance.Scan1000_pyr-jpeg_wld_wm_wmts_3d",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -14850,7 +14873,7 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Spot_edugeo_pyr_png_wld_wm": {
+        "Spot-edugeo_pyr-png_wld_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14869,11 +14892,11 @@
             "format": "image/png",
             "style": "normal",
             "variant": "SPOT-EDUGEO_PYR-PNG_WLD_WM",
-            "name": "GeoportailFrance.Spot_edugeo_pyr_png_wld_wm",
+            "name": "GeoportailFrance.Spot-edugeo_pyr-png_wld_wm",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Spot5_pyr_jpeg_wld_wm": {
+        "Spot5_pyr-jpeg_wld_wm": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
@@ -14892,7 +14915,7 @@
             "format": "image/png",
             "style": "normal",
             "variant": "SPOT5_PYR-JPEG_WLD_WM",
-            "name": "GeoportailFrance.Spot5_pyr_jpeg_wld_wm",
+            "name": "GeoportailFrance.Spot5_pyr-jpeg_wld_wm",
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
@@ -14934,7 +14957,7 @@
                 ]
             ],
             "min_zoom": 6,
-            "max_zoom": 20,
+            "max_zoom": 21,
             "format": "image/jpeg",
             "style": "normal",
             "variant": "THR.ORTHOIMAGERY.ORTHOPHOTOS",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2719,7 +2719,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-oslondon1k1893",
-            "name": "NLS.oslondon1k1893"
+            "name": "NLS.oslondon1k1893",
+            "apikey": "<insert your API key here>"
         }
     },
     "JusticeMap": {

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -8564,7 +8564,8 @@
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2002",
             "name": "GeoportailFrance.Ocsge_Constructions_2002",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Constructions_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8586,7 +8587,8 @@
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2011",
             "name": "GeoportailFrance.Ocsge_Constructions_2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Constructions_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8608,7 +8610,8 @@
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2014",
             "name": "GeoportailFrance.Ocsge_Constructions_2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Constructions_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8630,7 +8633,8 @@
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2016",
             "name": "GeoportailFrance.Ocsge_Constructions_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Constructions_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8718,7 +8722,8 @@
             "style": "normal",
             "variant": "OCSGE.COUVERTURE.2002",
             "name": "GeoportailFrance.Ocsge_Couverture_2002",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Couverture_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8740,7 +8745,8 @@
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2011",
             "name": "GeoportailFrance.Ocsge_Couverture_2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Couverture_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8762,7 +8768,8 @@
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2014",
             "name": "GeoportailFrance.Ocsge_Couverture_2014",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Couverture_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8784,7 +8791,8 @@
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2016",
             "name": "GeoportailFrance.Ocsge_Couverture_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Couverture_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8894,7 +8902,8 @@
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2011",
             "name": "GeoportailFrance.Ocsge_Usage_2011",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Usage_2014": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8938,7 +8947,8 @@
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2016",
             "name": "GeoportailFrance.Ocsge_Usage_2016",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Ocsge_Usage_2017": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11248,7 +11258,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.COAST2000",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Coast2000",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Orthoimagery_Orthophotos_Geneve": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11270,7 +11281,8 @@
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.GENEVE",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Geneve",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Orthoimagery_Orthophotos_Ilesdunord": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -12590,7 +12602,8 @@
             "style": "POINTS.INJECTION.BIOMETHANE",
             "variant": "POINTS.INJECTION.BIOMETHANE",
             "name": "GeoportailFrance.Points_Injection_Biomethane",
-            "TileMatrixSet": "PM"
+            "TileMatrixSet": "PM",
+            "status": "broken"
         },
         "Potentiel_Eolien_Reglementaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2891,7 +2891,7 @@
     },
     "GeoportailFrance": {
         "plan": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -2906,7 +2906,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
@@ -2914,7 +2913,7 @@
             "TileMatrixSet": "PM"
         },
         "parcels": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -2929,7 +2928,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PCI vecteur",
             "variant": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS",
@@ -2937,7 +2935,7 @@
             "TileMatrixSet": "PM"
         },
         "orthos": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -2952,7 +2950,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS",
@@ -2960,7 +2957,7 @@
             "TileMatrixSet": "PM"
         },
         "Acces_Biomethane": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -2974,8 +2971,7 @@
                 ]
             ],
             "min_zoom": 6,
-            "max_zoom": 18,
-            "apikey": "transports",
+            "max_zoom": 16,
             "format": "image/png",
             "style": "ACCES.BIOMETHANE",
             "variant": "ACCES.BIOMETHANE",
@@ -2983,7 +2979,7 @@
             "TileMatrixSet": "PM"
         },
         "Adminexpress_cog_carto_Latest": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -2998,7 +2994,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ADMINEXPRESS-COG-CARTO.LATEST",
@@ -3006,7 +3001,7 @@
             "TileMatrixSet": "PM"
         },
         "Adminexpress_cog_Latest": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3021,15 +3016,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ADMINEXPRESS-COG.LATEST",
             "name": "GeoportailFrance.Adminexpress_cog_Latest",
             "TileMatrixSet": "PM"
         },
-        "Adminexpress_2023-11-15": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Adminexpress_2023_11_15": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3044,15 +3038,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ADMINEXPRESS_2023-11-15",
-            "name": "GeoportailFrance.Adminexpress_2023-11-15",
+            "name": "GeoportailFrance.Adminexpress_2023_11_15",
             "TileMatrixSet": "PM"
         },
         "Adminexpress_cog_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3067,7 +3060,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ADMINEXPRESS_COG_2020",
@@ -3075,7 +3067,7 @@
             "TileMatrixSet": "PM"
         },
         "Areamanagement_Zfu": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3090,7 +3082,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "AREAMANAGEMENT.ZFU",
@@ -3098,7 +3089,7 @@
             "TileMatrixSet": "PM"
         },
         "Areamanagement_Zus": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3113,15 +3104,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "AREAMANAGEMENT.ZUS",
             "name": "GeoportailFrance.Areamanagement_Zus",
             "TileMatrixSet": "PM"
         },
-        "Aire-parcellaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Aire_parcellaire": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3136,15 +3126,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "Aire-Parcellaire",
-            "name": "GeoportailFrance.Aire-parcellaire",
+            "name": "GeoportailFrance.Aire_parcellaire",
             "TileMatrixSet": "PM"
         },
         "Bdcarto_etat_major_Niveau3": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3159,7 +3148,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "BDCARTO_ETAT-MAJOR.NIVEAU3",
@@ -3167,7 +3155,7 @@
             "TileMatrixSet": "PM"
         },
         "Bdcarto_etat_major_Niveau4": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3182,7 +3170,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "BDCARTO_ETAT-MAJOR.NIVEAU4",
@@ -3190,7 +3177,7 @@
             "TileMatrixSet": "PM"
         },
         "Besoin_Chaleur_Industriel": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3205,7 +3192,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BESOIN.CHALEUR.INDUSTRIEL",
             "variant": "BESOIN.CHALEUR.INDUSTRIEL",
@@ -3213,7 +3199,7 @@
             "TileMatrixSet": "PM"
         },
         "Besoin_Chaleur_Residentiel": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3228,7 +3214,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BESOIN.CHALEUR.RESIDENTIEL",
             "variant": "BESOIN.CHALEUR.RESIDENTIEL",
@@ -3236,7 +3221,7 @@
             "TileMatrixSet": "PM"
         },
         "Besoin_Chaleur_Tertiaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3251,7 +3236,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BESOIN.CHALEUR.TERTIAIRE",
             "variant": "BESOIN.CHALEUR.TERTIAIRE",
@@ -3259,7 +3243,7 @@
             "TileMatrixSet": "PM"
         },
         "Besoin_Froid_Residentiel": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3274,7 +3258,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BESOIN.FROID.RESIDENTIEL",
             "variant": "BESOIN.FROID.RESIDENTIEL",
@@ -3282,7 +3265,7 @@
             "TileMatrixSet": "PM"
         },
         "Besoin_Froid_Tertiaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3297,7 +3280,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BESOIN.FROID.TERTIAIRE",
             "variant": "BESOIN.FROID.TERTIAIRE",
@@ -3305,7 +3287,7 @@
             "TileMatrixSet": "PM"
         },
         "Buildings_Buildings": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3320,7 +3302,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BUILDINGS.BUILDINGS",
             "variant": "BUILDINGS.BUILDINGS",
@@ -3328,7 +3309,7 @@
             "TileMatrixSet": "PM"
         },
         "Cadastral_Parcels_Sections": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3343,7 +3324,6 @@
             ],
             "min_zoom": 13,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "CADASTRAL.PARCELS.SECTIONS",
@@ -3351,7 +3331,7 @@
             "TileMatrixSet": "PM"
         },
         "Cadastralparcels_Heatmap": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3366,7 +3346,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "DECALAGE DE LA REPRESENTATION CADASTRALE",
             "variant": "CADASTRALPARCELS.HEATMAP",
@@ -3374,7 +3353,7 @@
             "TileMatrixSet": "PM"
         },
         "Cadastralparcels_Histo_2008_2013_Parcels": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3389,7 +3368,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/png",
             "style": "bdparcellaire",
             "variant": "CADASTRALPARCELS.HISTO.2008-2013.PARCELS",
@@ -3397,7 +3375,7 @@
             "TileMatrixSet": "PM"
         },
         "Cadastralparcels_Parcels": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3412,7 +3390,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "CADASTRALPARCELS.PARCELS",
@@ -3420,7 +3397,7 @@
             "TileMatrixSet": "PM"
         },
         "Cadastralparcels_Qualrefbdp": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3435,7 +3412,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "DIVCAD_MTD",
             "variant": "CADASTRALPARCELS.QUALREFBDP",
@@ -3443,7 +3419,7 @@
             "TileMatrixSet": "PM"
         },
         "Cadastres_Solaires_Locaux": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3458,7 +3434,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CADASTRES.SOLAIRES.LOCAUX",
             "variant": "CADASTRES.SOLAIRES.LOCAUX",
@@ -3466,7 +3441,7 @@
             "TileMatrixSet": "PM"
         },
         "Capacite_Accueil_Electrique": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3481,15 +3456,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CAPACITE.ACCUEIL.ELECTRIQUE",
             "variant": "CAPACITE.ACCUEIL.ELECTRIQUE",
             "name": "GeoportailFrance.Capacite_Accueil_Electrique",
             "TileMatrixSet": "PM"
         },
-        "Cartes-14-18-edugeo_pyr-png_fxx_wm": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Cartes_14_18_edugeo_pyr_png_fxx_wm": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3504,15 +3478,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "CARTES-14-18-EDUGEO_PYR-PNG_FXX_WM",
-            "name": "GeoportailFrance.Cartes-14-18-edugeo_pyr-png_fxx_wm",
+            "name": "GeoportailFrance.Cartes_14_18_edugeo_pyr_png_fxx_wm",
             "TileMatrixSet": "PM"
         },
         "Cartes_Naturalearth": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3527,7 +3500,6 @@
             ],
             "min_zoom": 1,
             "max_zoom": 9,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "CARTES.NATURALEARTH",
@@ -3535,7 +3507,7 @@
             "TileMatrixSet": "PM"
         },
         "Cget_qp_bdd_wld_wm_wmts_20150914": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3550,7 +3522,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "CGET_QP_BDD_WLD_WM_WMTS_20150914",
@@ -3558,7 +3529,7 @@
             "TileMatrixSet": "PM"
         },
         "Communes_Prioritydisctrict": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3573,7 +3544,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "COMMUNES.PRIORITYDISCTRICT",
@@ -3581,7 +3551,7 @@
             "TileMatrixSet": "PM"
         },
         "Communes_Sismicite": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3596,7 +3566,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "COMMUNES.SISMICITE",
@@ -3604,7 +3573,7 @@
             "TileMatrixSet": "PM"
         },
         "Conso_Elec_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3619,7 +3588,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CONSO.ELEC.COMMUNE",
             "variant": "CONSO.ELEC.COMMUNE",
@@ -3627,7 +3595,7 @@
             "TileMatrixSet": "PM"
         },
         "Conso_Gaz_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3642,7 +3610,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CONSO.GAZ.COMMUNE",
             "variant": "CONSO.GAZ.COMMUNE",
@@ -3650,7 +3617,7 @@
             "TileMatrixSet": "PM"
         },
         "Debroussaillement": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3665,7 +3632,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "DEBROUSSAILLEMENT",
@@ -3673,7 +3639,7 @@
             "TileMatrixSet": "PM"
         },
         "Delaisses_Autoroutiers": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3688,7 +3654,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "DELAISSES.AUTOROUTIERS",
             "variant": "DELAISSES.AUTOROUTIERS",
@@ -3696,7 +3661,7 @@
             "TileMatrixSet": "PM"
         },
         "Dreal_Zonage_pinel": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3711,7 +3676,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "DREAL.ZONAGE_PINEL",
@@ -3719,7 +3683,7 @@
             "TileMatrixSet": "PM"
         },
         "Edugeo_Landuse_Agriculture2012": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3734,7 +3698,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "EDUGEO.LANDUSE.AGRICULTURE2012",
@@ -3742,7 +3705,7 @@
             "TileMatrixSet": "PM"
         },
         "Edugeo_Naturalriskzones_1910floodedwatersheds": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3757,7 +3720,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "EDUGEO.NATURALRISKZONES.1910FLOODEDWATERSHEDS",
@@ -3765,7 +3727,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevation_Contour_Line": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3780,7 +3742,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ELEVATION.CONTOUR.LINE",
@@ -3788,7 +3749,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevation_Elevationgridcoverage_Shadow": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3803,7 +3764,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/png",
             "style": "estompage_grayscale",
             "variant": "ELEVATION.ELEVATIONGRIDCOVERAGE.SHADOW",
@@ -3811,7 +3771,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevation_Elevationgridcoverage_Threshold": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3826,7 +3786,6 @@
             ],
             "min_zoom": 3,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ELEVATION.ELEVATIONGRIDCOVERAGE.THRESHOLD",
             "variant": "ELEVATION.ELEVATIONGRIDCOVERAGE.THRESHOLD",
@@ -3834,7 +3793,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevation_Level0": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3849,7 +3808,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ELEVATION.LEVEL0",
@@ -3857,7 +3815,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevation_Slopes": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3872,7 +3830,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 14,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ELEVATION.SLOPES",
@@ -3880,7 +3837,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevation_Slopes_Highres": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3895,7 +3852,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ELEVATION.SLOPES.HIGHRES",
@@ -3903,7 +3859,7 @@
             "TileMatrixSet": "PM"
         },
         "Elevationgridcoverage_Highres_Quality": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3918,7 +3874,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "Graphe de source du RGE Alti",
             "variant": "ELEVATIONGRIDCOVERAGE.HIGHRES.QUALITY",
@@ -3926,7 +3881,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Aero_Civil": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3941,7 +3896,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENR.AERO.CIVIL",
             "variant": "ENR.AERO.CIVIL",
@@ -3949,7 +3903,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Aero_Militaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3964,7 +3918,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENR.AERO.MILITAIRE",
             "variant": "ENR.AERO.MILITAIRE",
@@ -3972,7 +3925,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Grands_Sites_France": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -3987,7 +3940,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENR.GRANDS.SITES.FRANCE",
             "variant": "ENR.GRANDS.SITES.FRANCE",
@@ -3995,7 +3947,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Perimetre_Habitation": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4010,7 +3962,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PERIMETRE.HABITATION",
             "variant": "ENR.PERIMETRE.HABITATION",
@@ -4018,7 +3969,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Perimetre_Pente": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4033,7 +3984,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PERIMETRE.PENTE",
             "variant": "ENR.PERIMETRE.PENTE",
@@ -4041,7 +3991,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Perimetre_Route": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4056,7 +4006,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PERIMETRE.ROUTE",
             "variant": "ENR.PERIMETRE.ROUTE",
@@ -4064,7 +4013,7 @@
             "TileMatrixSet": "PM"
         },
         "Enr_Perimetre_Voie_Ferree": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4079,7 +4028,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PERIMETRE.VOIE.FERREE",
             "variant": "ENR.PERIMETRE.VOIE.FERREE",
@@ -4087,7 +4035,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Besoins_Chaud": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4102,7 +4050,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.BESOINS.CHAUD",
             "variant": "ENREZO.BESOINS.CHAUD",
@@ -4110,7 +4057,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Besoins_Froid": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4125,7 +4072,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.BESOINS.FROID",
             "variant": "ENREZO.BESOINS.FROID",
@@ -4133,7 +4079,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Chaleur_Fatale_500_Industries": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4148,7 +4094,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.CHALEUR.FATALE.500.INDUSTRIES",
             "variant": "ENREZO.CHALEUR.FATALE.500.INDUSTRIES",
@@ -4156,7 +4101,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Chaleur_Fatale_Datacenter": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4171,7 +4116,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.CHALEUR.FATALE.DATACENTER",
             "variant": "ENREZO.CHALEUR.FATALE.DATACENTER",
@@ -4179,7 +4123,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Chaleur_Fatale_Step": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4194,7 +4138,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.CHALEUR.FATALE.STEP",
             "variant": "ENREZO.CHALEUR.FATALE.STEP",
@@ -4202,7 +4145,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Zone_Potentiel_Chaud": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4217,7 +4160,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.ZONE.POTENTIEL.CHAUD",
             "variant": "ENREZO.ZONE.POTENTIEL.CHAUD",
@@ -4225,7 +4167,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Zone_Potentiel_Fort_Chaud": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4240,7 +4182,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.ZONE.POTENTIEL.FORT.CHAUD",
             "variant": "ENREZO.ZONE.POTENTIEL.FORT.CHAUD",
@@ -4248,7 +4189,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Zone_Potentiel_Fort_Froid": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4263,7 +4204,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.ZONE.POTENTIEL.FORT.FROID",
             "variant": "ENREZO.ZONE.POTENTIEL.FORT.FROID",
@@ -4271,7 +4211,7 @@
             "TileMatrixSet": "PM"
         },
         "Enrezo_Zone_Potentiel_Froid": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4286,15 +4226,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ENREZO.ZONE.POTENTIEL.FROID",
             "variant": "ENREZO.ZONE.POTENTIEL.FROID",
             "name": "GeoportailFrance.Enrezo_Zone_Potentiel_Froid",
             "TileMatrixSet": "PM"
         },
-        "Evol-surface-forestiere-1980-2011_edugeo_pyr-png_fxx_lamb93_20150918": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Evol_surface_forestiere_1980_2011_edugeo_pyr_png_fxx_lamb93_20150918": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4309,15 +4248,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "EVOL-SURFACE-FORESTIERE-1980-2011_EDUGEO_PYR-PNG_FXX_LAMB93_20150918",
-            "name": "GeoportailFrance.Evol-surface-forestiere-1980-2011_edugeo_pyr-png_fxx_lamb93_20150918",
+            "name": "GeoportailFrance.Evol_surface_forestiere_1980_2011_edugeo_pyr_png_fxx_lamb93_20150918",
             "TileMatrixSet": "PM"
         },
         "Forets_Publiques": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4332,7 +4270,6 @@
             ],
             "min_zoom": 3,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "FORETS PUBLIQUES ONF",
             "variant": "FORETS.PUBLIQUES",
@@ -4340,7 +4277,7 @@
             "TileMatrixSet": "PM"
         },
         "Gaz_Corridor_Distribution": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4355,7 +4292,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "GAZ.CORRIDOR.DISTRIBUTION",
             "variant": "GAZ.CORRIDOR.DISTRIBUTION",
@@ -4363,7 +4299,7 @@
             "TileMatrixSet": "PM"
         },
         "Gaz_Corridor_Transport": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4378,7 +4314,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "GAZ.CORRIDOR.TRANSPORT",
             "variant": "GAZ.CORRIDOR.TRANSPORT",
@@ -4386,7 +4321,7 @@
             "TileMatrixSet": "PM"
         },
         "Gaz_Reseau_Distribution": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4401,7 +4336,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "GAZ.RESEAU.DISTRIBUTION",
             "variant": "GAZ.RESEAU.DISTRIBUTION",
@@ -4409,7 +4343,7 @@
             "TileMatrixSet": "PM"
         },
         "Gaz_Reseau_Transport": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4424,15 +4358,36 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "GAZ.RESEAU.TRANSPORT",
             "variant": "GAZ.RESEAU.TRANSPORT",
             "name": "GeoportailFrance.Gaz_Reseau_Transport",
             "TileMatrixSet": "PM"
         },
+        "Geographicalgridsystem_Dfci": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "attribution": "Geoportail France",
+            "bounds": [
+                [
+                    41.3252,
+                    -5.15047
+                ],
+                [
+                    51.0991,
+                    9.57054
+                ]
+            ],
+            "min_zoom": 6,
+            "max_zoom": 16,
+            "format": "image/png",
+            "style": "normal",
+            "variant": "GEOGRAPHICALGRIDSYSTEM.DFCI",
+            "name": "GeoportailFrance.Geographicalgridsystem_Dfci",
+            "TileMatrixSet": "PM"
+        },
         "Geographicalgridsystems_1900typemaps": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4447,7 +4402,6 @@
             ],
             "min_zoom": 10,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.1900TYPEMAPS",
@@ -4455,7 +4409,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_1914_11_15_arras_verdun_belfort_fronts_600k": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4470,7 +4424,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 10,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.1914_11_15_ARRAS_VERDUN_BELFORT_fronts_600K",
@@ -4478,7 +4431,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Bonne": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4493,7 +4446,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 10,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.BONNE",
@@ -4501,7 +4453,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Coastalmaps": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4516,7 +4468,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.COASTALMAPS",
@@ -4524,7 +4475,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Douaumont_fort_positions_5k_18mai1916": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4539,7 +4490,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.DOUAUMONT_FORT_positions_5K_18mai1916",
@@ -4547,7 +4497,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Ajaccio1976": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4562,7 +4512,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.AJACCIO1976",
@@ -4570,7 +4519,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Belfort_montbelliard1973": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4585,7 +4534,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BELFORT-MONTBELLIARD1973",
@@ -4593,7 +4541,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Berry_sud1952": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4608,7 +4556,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BERRY-SUD1952",
@@ -4616,7 +4563,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Bethune1956": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4631,7 +4578,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BETHUNE1956",
@@ -4639,7 +4585,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Biarritz1979": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4654,7 +4600,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BIARRITZ1979",
@@ -4662,7 +4607,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Bourg_st_maurice1974": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4677,7 +4622,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.BOURG-ST-MAURICE1974",
@@ -4685,7 +4629,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Caen1969": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4700,7 +4644,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CAEN1969",
@@ -4708,7 +4651,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Cap_dagde1971": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4723,7 +4666,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CAP-DAGDE1971",
@@ -4731,7 +4673,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Clermont_ferrand1966": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4746,7 +4688,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CLERMONT-FERRAND1966",
@@ -4754,7 +4695,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Creil_sud_picardie1979": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4769,7 +4710,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.CREIL-SUD-PICARDIE1979",
@@ -4777,7 +4717,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Dijon1962": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4792,7 +4732,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.DIJON1962",
@@ -4800,7 +4739,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Douaumont1916": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4815,7 +4754,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.Douaumont1916",
@@ -4823,7 +4761,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Grenoble1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4838,7 +4776,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GRENOBLE1965",
@@ -4846,7 +4783,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Grenoble1976": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4861,7 +4798,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GRENOBLE1976",
@@ -4869,7 +4805,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Grenoble1991": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4884,7 +4820,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GRENOBLE1991",
@@ -4892,7 +4827,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Guadeloupe1955": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4907,7 +4842,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GUADELOUPE1955",
@@ -4915,7 +4849,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Guyane1958": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4930,7 +4864,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.GUYANE1958",
@@ -4938,7 +4871,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_La_reunion1980": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4953,7 +4886,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LA-REUNION1980",
@@ -4961,7 +4893,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_La_rochelle_rochefort1959": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4976,7 +4908,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LA-ROCHELLE-ROCHEFORT1959",
@@ -4984,7 +4915,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Le_havre1975": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -4999,7 +4930,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LE-HAVRE1975",
@@ -5007,7 +4937,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Le_havre1979": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5022,7 +4952,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LE-HAVRE1979",
@@ -5030,7 +4959,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Limoges1966": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5045,7 +4974,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LIMOGES1966",
@@ -5053,7 +4981,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Lyon1947": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5068,7 +4996,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1947",
@@ -5076,7 +5003,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Lyon1980": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5091,7 +5018,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1980",
@@ -5099,7 +5025,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Lyon1985": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5114,7 +5040,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1985",
@@ -5122,7 +5047,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Le_mort_homme_et_ses_environs_avril_1916": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5137,7 +5062,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.Le-Mort-Homme-et-ses-environs-avril-1916",
@@ -5145,7 +5069,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Marne_la_vallee1966": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5160,7 +5084,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARNE-LA-VALLEE1966",
@@ -5168,7 +5091,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Marne_la_vallee1978": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5183,7 +5106,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARNE-LA-VALLEE1978",
@@ -5191,7 +5113,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Marne_la_vallee1987": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5206,7 +5128,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARNE-LA-VALLEE1987",
@@ -5214,7 +5135,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Marseille_martigues1947": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5229,7 +5150,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARSEILLE-MARTIGUES1947",
@@ -5237,7 +5157,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Marseille_martigues1980": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5252,7 +5172,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARSEILLE-MARTIGUES1980",
@@ -5260,7 +5179,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Marseille_martigues1986": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5275,7 +5194,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.MARSEILLE-MARTIGUES1986",
@@ -5283,7 +5201,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Metz_nancy1983": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5298,7 +5216,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.METZ-NANCY1983",
@@ -5306,7 +5223,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Nantes1972": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5321,7 +5238,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.NANTES1972",
@@ -5329,7 +5245,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Paris1964": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5344,7 +5260,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.PARIS1964",
@@ -5352,7 +5267,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Paris1979": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5367,7 +5282,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.PARIS1979",
@@ -5375,7 +5289,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Positions_20k_avr1916": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5390,7 +5304,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.Positions_20K_avr1916",
@@ -5398,7 +5311,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Reims1974": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5413,7 +5326,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.REIMS1974",
@@ -5421,7 +5333,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Roissy1973": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5436,7 +5348,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.ROISSY1973",
@@ -5444,7 +5355,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Roissy1978": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5459,7 +5370,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.ROISSY1978",
@@ -5467,7 +5377,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Strasbourg1956": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5482,7 +5392,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.STRASBOURG1956",
@@ -5490,7 +5399,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Strasbourg1978": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5505,7 +5414,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.STRASBOURG1978",
@@ -5513,7 +5421,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Toulon_hyeres1976": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5528,7 +5436,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.TOULON-HYERES1976",
@@ -5536,7 +5443,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Toulouse1948": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5551,7 +5458,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.TOULOUSE1948",
@@ -5559,7 +5465,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Vannes_golfe_du_morbihan1960": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5574,7 +5480,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VANNES-GOLFE-DU-MORBIHAN1960",
@@ -5582,7 +5487,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Vannes_golfe_du_morbihan1971": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5597,7 +5502,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VANNES-GOLFE-DU-MORBIHAN1971",
@@ -5605,7 +5509,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Verdun_nord_fronts_francais_20k": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5620,7 +5524,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VERDUN_NORD_fronts_francais_20K",
@@ -5628,7 +5531,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Verdun_nord_organisations_defensives_20k": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5643,7 +5546,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VERDUN_NORD_organisations_defensives_20K",
@@ -5651,7 +5553,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Edugeo_Versailles1979": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5666,7 +5568,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.EDUGEO.VERSAILLES1979",
@@ -5674,7 +5575,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Etatmajor10": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5689,7 +5590,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10",
@@ -5697,7 +5597,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Etatmajor40": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5712,15 +5612,36 @@
             ],
             "min_zoom": 6,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR40",
             "name": "GeoportailFrance.Geographicalgridsystems_Etatmajor40",
             "TileMatrixSet": "PM"
         },
+        "Geographicalgridsystems_Maps_Bduni_J1": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "attribution": "Geoportail France",
+            "bounds": [
+                [
+                    -80.0,
+                    -180.0
+                ],
+                [
+                    80.0,
+                    180.0
+                ]
+            ],
+            "min_zoom": 0,
+            "max_zoom": 18,
+            "format": "image/png",
+            "style": "normal",
+            "variant": "GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1",
+            "name": "GeoportailFrance.Geographicalgridsystems_Maps_Bduni_J1",
+            "TileMatrixSet": "PM"
+        },
         "Geographicalgridsystems_Maps_Overview": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5735,7 +5656,6 @@
             ],
             "min_zoom": 1,
             "max_zoom": 8,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.MAPS.OVERVIEW",
@@ -5743,7 +5663,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Maps_Scan50_1950": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5758,7 +5678,6 @@
             ],
             "min_zoom": 3,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN50.1950",
@@ -5766,7 +5685,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Slopes_Mountain": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5781,7 +5700,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.SLOPES.MOUNTAIN",
@@ -5789,7 +5707,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Slopes_Pac": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5804,7 +5722,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/png",
             "style": "GEOGRAPHICALGRIDSYSTEMS.SLOPES.PAC",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.SLOPES.PAC",
@@ -5812,7 +5729,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Terrier_v1": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5827,7 +5744,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.TERRIER_V1",
@@ -5835,7 +5751,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Terrier_v2": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5850,7 +5766,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.TERRIER_V2",
@@ -5858,7 +5773,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Verdun_environs_nord_fronts_offensves_50k": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5873,7 +5788,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 14,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.VERDUN_ENVIRONS_NORD_fronts_offensves_50K",
@@ -5881,7 +5795,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Verdun_environs_sud_nord_com_group_80k": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5896,7 +5810,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.VERDUN_ENVIRONS_SUD_NORD_com_group_80K",
@@ -5904,7 +5817,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalgridsystems_Verdun_environs_fronts_50k_21_26fevr1916": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5919,7 +5832,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 14,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALGRIDSYSTEMS.VERDUN_ENVIRONS_fronts_50K_21-26fevr1916",
@@ -5927,7 +5839,7 @@
             "TileMatrixSet": "PM"
         },
         "Geographicalnames_Names": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5942,7 +5854,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "GEOGRAPHICALNAMES.NAMES",
@@ -5950,7 +5861,7 @@
             "TileMatrixSet": "PM"
         },
         "Hr_Orthoimagery_Orthophotos": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5965,7 +5876,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "HR.ORTHOIMAGERY.ORTHOPHOTOS",
@@ -5973,7 +5883,7 @@
             "TileMatrixSet": "PM"
         },
         "Hydrography_Bcae_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -5988,7 +5898,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "HYDROGRAPHY.BCAE.2020",
@@ -5996,7 +5905,7 @@
             "TileMatrixSet": "PM"
         },
         "Hydrography_Bcae_2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6011,7 +5920,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "HYDROGRAPHY.BCAE.2021",
@@ -6019,7 +5927,7 @@
             "TileMatrixSet": "PM"
         },
         "Hydrography_Bcae_2022": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6034,7 +5942,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.2022",
@@ -6042,7 +5949,7 @@
             "TileMatrixSet": "PM"
         },
         "Hydrography_Bcae_2024": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6057,7 +5964,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.2024",
@@ -6065,7 +5971,7 @@
             "TileMatrixSet": "PM"
         },
         "Hydrography_Bcae_Latest": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6080,7 +5986,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "HYDROGRAPHY.BCAE.LATEST",
@@ -6088,7 +5993,7 @@
             "TileMatrixSet": "PM"
         },
         "Hydrography_Hydrography": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6103,7 +6008,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "HYDROGRAPHY.HYDROGRAPHY",
@@ -6111,7 +6015,7 @@
             "TileMatrixSet": "PM"
         },
         "Inpe": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6126,7 +6030,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INPE",
             "variant": "INPE",
@@ -6134,7 +6037,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Enfants_0_17_Ans_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6149,7 +6052,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.ENFANTS.0.17.ANS.SECRET",
@@ -6157,7 +6059,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Logements_Surface_Moyenne_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6172,7 +6074,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.LOGEMENTS.SURFACE.MOYENNE.SECRET",
@@ -6180,7 +6081,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Niveau_De_Vie_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6195,7 +6096,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.NIVEAU.DE.VIE.SECRET",
@@ -6203,7 +6103,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Familles_Monoparentales_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6218,7 +6118,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.FAMILLES.MONOPARENTALES.SECRET",
@@ -6226,7 +6125,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Individus_25_39_Ans_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6241,7 +6140,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.INDIVIDUS.25.39.ANS.SECRET",
@@ -6249,7 +6147,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Individus_40_54_Ans_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6264,7 +6162,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.INDIVIDUS.40.54.ANS.SECRET",
@@ -6272,7 +6169,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Individus_55_64_Ans_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6287,7 +6184,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.INDIVIDUS.55.64.ANS.SECRET",
@@ -6295,7 +6191,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Logements_Apres_1990_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6310,7 +6206,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.APRES.1990.SECRET",
@@ -6318,7 +6213,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Logements_Avant_1945_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6333,7 +6228,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.AVANT.1945.SECRET",
@@ -6341,7 +6235,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Logements_Collectifs_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6356,7 +6250,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.COLLECTIFS.SECRET",
@@ -6364,7 +6257,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Logements_Construits_1945_1970_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6379,7 +6272,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.CONSTRUITS.1945.1970.SECRET",
@@ -6387,7 +6279,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Logements_Construits_1970_1990_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6402,7 +6294,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.CONSTRUITS.1970.1990.SECRET",
@@ -6410,7 +6301,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Logements_Sociaux_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6425,7 +6316,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.LOGEMENTS.SOCIAUX.SECRET",
@@ -6433,7 +6323,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Menages_1_Personne_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6448,7 +6338,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.1.PERSONNE.SECRET",
@@ -6456,7 +6345,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Menages_5_Personnes_Ouplus_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6471,7 +6360,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.5.PERSONNES.OUPLUS.SECRET",
@@ -6479,7 +6367,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Menages_Maison_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6494,7 +6382,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.MAISON.SECRET",
@@ -6502,7 +6389,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Menages_Pauvres_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6517,7 +6404,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.PAUVRES.SECRET",
@@ -6525,7 +6411,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Menages_Proprietaires_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6540,7 +6426,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.MENAGES.PROPRIETAIRES.SECRET",
@@ -6548,7 +6433,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Part_Plus_65_Ans_Secret": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6563,7 +6448,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.PART.PLUS.65.ANS.SECRET",
@@ -6571,7 +6455,7 @@
             "TileMatrixSet": "PM"
         },
         "Insee_Filosofi_Population": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6586,7 +6470,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "INSEE",
             "variant": "INSEE.FILOSOFI.POPULATION",
@@ -6594,7 +6477,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha00": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6609,7 +6492,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA00",
@@ -6617,7 +6499,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha00_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6632,7 +6514,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA00_FR",
@@ -6640,7 +6521,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha06": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6655,7 +6536,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA06",
@@ -6663,7 +6543,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha06_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6678,7 +6558,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA06_DOM",
@@ -6686,7 +6565,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha06_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6701,7 +6580,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA06_FR",
@@ -6709,7 +6587,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha12": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6724,7 +6602,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA12",
@@ -6732,7 +6609,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha12_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6747,7 +6624,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA12_DOM",
@@ -6755,7 +6631,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha12_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6770,7 +6646,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA12_FR",
@@ -6778,7 +6653,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha18": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6793,7 +6668,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.CHA18",
@@ -6801,7 +6675,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha18_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6816,7 +6690,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CHA18_DOM",
@@ -6824,7 +6697,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Cha18_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6839,7 +6712,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CHA18_FR",
@@ -6847,7 +6719,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc00": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6862,7 +6734,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC00",
@@ -6870,7 +6741,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc00r": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6885,7 +6756,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC00R",
@@ -6893,7 +6763,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc00r_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6908,7 +6778,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC00R_FR",
@@ -6916,7 +6785,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc00_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6931,7 +6800,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC00_DOM",
@@ -6939,7 +6807,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc00_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6954,7 +6822,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC00_FR",
@@ -6962,7 +6829,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc06": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -6977,7 +6844,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06",
@@ -6985,7 +6851,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc06r": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7000,7 +6866,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06R",
@@ -7008,7 +6873,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc06r_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7023,7 +6888,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06R_DOM",
@@ -7031,7 +6895,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc06r_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7046,7 +6910,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC06R_FR",
@@ -7054,7 +6917,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc06_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7069,7 +6932,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC06_DOM",
@@ -7077,7 +6939,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc06_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7092,7 +6954,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC06_FR",
@@ -7100,7 +6961,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc12": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7115,7 +6976,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC12",
@@ -7123,7 +6983,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc12r": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7138,7 +6998,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.CLC12R",
@@ -7146,7 +7005,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc12r_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7161,7 +7020,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC12R_DOM",
@@ -7169,7 +7027,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc12r_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7184,7 +7042,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC12R_FR",
@@ -7192,7 +7049,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc12_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7207,7 +7064,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC12_DOM",
@@ -7215,7 +7071,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc12_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7230,7 +7086,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC12_FR",
@@ -7238,7 +7093,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc18": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7253,7 +7108,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.CLC18",
@@ -7261,7 +7115,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc18_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7276,7 +7130,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.CLC18_DOM",
@@ -7284,7 +7137,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc18_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7299,7 +7152,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC18_FR",
@@ -7307,7 +7159,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc90": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7322,7 +7174,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC90",
@@ -7330,7 +7181,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Clc90_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7345,7 +7196,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.CLC90_FR",
@@ -7353,7 +7203,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Evol_surface_forestiere_1980_2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7368,7 +7218,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.EVOL_SURFACE_FORESTIERE_1980-2011",
@@ -7376,7 +7225,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Klaus": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7391,7 +7240,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.KLAUS",
@@ -7399,7 +7247,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Lgv_archeologie": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7414,7 +7262,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_archeologie",
@@ -7422,7 +7269,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Lgv_faune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7437,7 +7284,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_faune",
@@ -7445,7 +7291,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Lgv_flore": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7460,7 +7306,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_flore",
@@ -7468,7 +7313,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Lgv_technique": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7483,7 +7328,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.LGV_technique",
@@ -7491,7 +7335,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Edugeo_Taux_boisement_2009_2013": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7506,7 +7350,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.EDUGEO.TAUX_BOISEMENT_2009-2013",
@@ -7514,7 +7357,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Forestareas": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7529,7 +7372,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.FORESTAREAS",
@@ -7537,7 +7379,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Forestinventory_V1": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7552,7 +7394,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.FORESTINVENTORY.V1",
@@ -7560,7 +7401,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Forestinventory_V2": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7575,7 +7416,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "LANDCOVER.FORESTINVENTORY.V2",
             "variant": "LANDCOVER.FORESTINVENTORY.V2",
@@ -7583,7 +7423,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc00": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7598,7 +7438,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC00",
@@ -7606,7 +7445,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc00r_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7621,7 +7460,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC00R_FR",
@@ -7629,7 +7467,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc00_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7644,7 +7482,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC00_DOM",
@@ -7652,7 +7489,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc00_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7667,7 +7504,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC00_FR",
@@ -7675,7 +7511,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc06": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7690,7 +7526,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC06",
@@ -7698,7 +7533,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc06r": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7713,7 +7548,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC06R",
@@ -7721,7 +7555,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc06r_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7736,7 +7570,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC06R_DOM",
@@ -7744,7 +7577,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc06r_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7759,7 +7592,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC06R_FR",
@@ -7767,7 +7599,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc06_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7782,7 +7614,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC06_DOM",
@@ -7790,7 +7621,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc06_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7805,7 +7636,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC06_FR",
@@ -7813,7 +7643,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc12": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7828,7 +7658,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover",
             "variant": "LANDCOVER.GRID.CLC12",
@@ -7836,7 +7665,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc12_dom": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7851,7 +7680,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - DOM",
             "variant": "LANDCOVER.GRID.CLC12_DOM",
@@ -7859,7 +7687,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc12_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7874,7 +7702,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC12_FR",
@@ -7882,7 +7709,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Grid_Clc90_fr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7897,7 +7724,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - France m\u00e9tropolitaine",
             "variant": "LANDCOVER.GRID.CLC90_FR",
@@ -7905,7 +7731,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Dlt_Clc12": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7920,7 +7746,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - type de for\u00eats",
             "variant": "LANDCOVER.HR.DLT.CLC12",
@@ -7928,7 +7753,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Dlt_Clc15": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7943,7 +7768,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - type de for\u00eats",
             "variant": "LANDCOVER.HR.DLT.CLC15",
@@ -7951,7 +7775,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Gra_Clc15": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7966,7 +7790,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - prairies",
             "variant": "LANDCOVER.HR.GRA.CLC15",
@@ -7974,7 +7797,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Imd_Clc12": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -7989,7 +7812,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - taux d'imperm\u00e9abilisation des sols",
             "variant": "LANDCOVER.HR.IMD.CLC12",
@@ -7997,7 +7819,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Imd_Clc15": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8012,7 +7834,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - taux d'imperm\u00e9abilisation des sols",
             "variant": "LANDCOVER.HR.IMD.CLC15",
@@ -8020,7 +7841,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Tcd_Clc12": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8035,7 +7856,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - taux de couvert arbor\u00e9",
             "variant": "LANDCOVER.HR.TCD.CLC12",
@@ -8043,7 +7863,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Tcd_Clc15": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8058,7 +7878,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - taux de couvert arbor\u00e9",
             "variant": "LANDCOVER.HR.TCD.CLC15",
@@ -8066,7 +7885,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Hr_Waw_Clc15": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8081,7 +7900,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 13,
-            "apikey": "transports",
             "format": "image/png",
             "style": "CORINE Land Cover - HR - zones humides et surfaces en eaux permanentes",
             "variant": "LANDCOVER.HR.WAW.CLC15",
@@ -8089,7 +7907,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Sylvoecoregions": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8104,7 +7922,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.SYLVOECOREGIONS",
@@ -8112,7 +7929,7 @@
             "TileMatrixSet": "PM"
         },
         "Landcover_Sylvoecoregions_Alluvium": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8127,7 +7944,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDCOVER.SYLVOECOREGIONS.ALLUVIUM",
@@ -8135,7 +7951,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture_Latest": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8150,7 +7966,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE.LATEST",
@@ -8158,7 +7973,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2007": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8173,7 +7988,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2007",
@@ -8181,7 +7995,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2008": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8196,7 +8010,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2008",
@@ -8204,7 +8017,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2009": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8219,7 +8032,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2009",
@@ -8227,7 +8039,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8242,7 +8054,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2010",
@@ -8250,7 +8061,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8265,7 +8076,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2011",
@@ -8273,7 +8083,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2012": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8288,7 +8098,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2012",
@@ -8296,7 +8105,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2013": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8311,7 +8120,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2013",
@@ -8319,7 +8127,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8334,7 +8142,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2014",
@@ -8342,7 +8149,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2015": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8357,7 +8164,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2015",
@@ -8365,7 +8171,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8380,7 +8186,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2016",
@@ -8388,7 +8193,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8403,7 +8208,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2017",
@@ -8411,7 +8215,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8426,7 +8230,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2018",
@@ -8434,7 +8237,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8449,7 +8252,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2019",
@@ -8457,7 +8259,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8472,7 +8274,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2020",
@@ -8480,7 +8281,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8495,7 +8296,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2021",
@@ -8503,7 +8303,7 @@
             "TileMatrixSet": "PM"
         },
         "Landuse_Agriculture2022": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8518,15 +8318,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LANDUSE.AGRICULTURE2022",
             "name": "GeoportailFrance.Landuse_Agriculture2022",
             "TileMatrixSet": "PM"
         },
-        "Lgv_edugeo_archeologie_pyr-png_fxx_wm_20170210": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Lgv_edugeo_archeologie_pyr_png_fxx_wm_20170210": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8541,15 +8340,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_ARCHEOLOGIE_PYR-PNG_FXX_WM_20170210",
-            "name": "GeoportailFrance.Lgv_edugeo_archeologie_pyr-png_fxx_wm_20170210",
+            "name": "GeoportailFrance.Lgv_edugeo_archeologie_pyr_png_fxx_wm_20170210",
             "TileMatrixSet": "PM"
         },
-        "Lgv_edugeo_faune_pyr-png_fxx_wm_20170215": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Lgv_edugeo_faune_pyr_png_fxx_wm_20170215": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8564,15 +8362,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_FAUNE_PYR-PNG_FXX_WM_20170215",
-            "name": "GeoportailFrance.Lgv_edugeo_faune_pyr-png_fxx_wm_20170215",
+            "name": "GeoportailFrance.Lgv_edugeo_faune_pyr_png_fxx_wm_20170215",
             "TileMatrixSet": "PM"
         },
-        "Lgv_edugeo_flore_pyr-png_fxx_wm_20170213": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Lgv_edugeo_flore_pyr_png_fxx_wm_20170213": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8587,15 +8384,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_FLORE_PYR-PNG_FXX_WM_20170213",
-            "name": "GeoportailFrance.Lgv_edugeo_flore_pyr-png_fxx_wm_20170213",
+            "name": "GeoportailFrance.Lgv_edugeo_flore_pyr_png_fxx_wm_20170213",
             "TileMatrixSet": "PM"
         },
-        "Lgv_edugeo_technique_pyr-png_fxx_wm_20170215": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Lgv_edugeo_technique_pyr_png_fxx_wm_20170215": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8610,15 +8406,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LGV_EDUGEO_TECHNIQUE_PYR-PNG_FXX_WM_20170215",
-            "name": "GeoportailFrance.Lgv_edugeo_technique_pyr-png_fxx_wm_20170215",
+            "name": "GeoportailFrance.Lgv_edugeo_technique_pyr_png_fxx_wm_20170215",
             "TileMatrixSet": "PM"
         },
         "Limites_administratives_express_Latest": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8633,7 +8428,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
@@ -8641,7 +8435,7 @@
             "TileMatrixSet": "PM"
         },
         "Localisation_Mats_Eolien": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8656,7 +8450,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "LOCALISATION.MATS.EOLIEN",
             "variant": "LOCALISATION.MATS.EOLIEN",
@@ -8664,7 +8457,7 @@
             "TileMatrixSet": "PM"
         },
         "Lot_Chasse": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8679,15 +8472,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LOT.CHASSE",
             "name": "GeoportailFrance.Lot_Chasse",
             "TileMatrixSet": "PM"
         },
-        "Lsep-crue_pyr-png_wld_wm_edugeo_20130128": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Lsep_crue_pyr_png_wld_wm_edugeo_20130128": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8702,15 +8494,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "LSEP-CRUE_PYR-PNG_WLD_WM_EDUGEO_20130128",
-            "name": "GeoportailFrance.Lsep-crue_pyr-png_wld_wm_edugeo_20130128",
+            "name": "GeoportailFrance.Lsep_crue_pyr_png_wld_wm_edugeo_20130128",
             "TileMatrixSet": "PM"
         },
         "Naturalriskzones_1910floodedwatersheds": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8725,7 +8516,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "NATURALRISKZONES.1910FLOODEDWATERSHEDS",
@@ -8733,7 +8523,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8748,7 +8538,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "OCSGE.CONSTRUCTIONS",
@@ -8756,7 +8545,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions_2002": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8771,16 +8560,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2002",
             "name": "GeoportailFrance.Ocsge_Constructions_2002",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions_2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8795,7 +8582,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2011",
@@ -8803,7 +8589,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions_2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8818,16 +8604,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2014",
             "name": "GeoportailFrance.Ocsge_Constructions_2014",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8842,7 +8626,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2016",
@@ -8850,7 +8633,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8865,7 +8648,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2017",
@@ -8873,7 +8655,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Constructions_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8888,7 +8670,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.CONSTRUCTIONS.2019",
@@ -8896,7 +8677,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8911,7 +8692,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "OCSGE.COUVERTURE",
@@ -8919,7 +8699,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture_2002": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8934,16 +8714,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "OCSGE.COUVERTURE.2002",
             "name": "GeoportailFrance.Ocsge_Couverture_2002",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture_2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8958,7 +8736,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2011",
@@ -8966,7 +8743,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture_2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -8981,16 +8758,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2014",
             "name": "GeoportailFrance.Ocsge_Couverture_2014",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9005,7 +8780,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2016",
@@ -9013,7 +8787,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9028,7 +8802,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2017",
@@ -9036,7 +8809,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Couverture_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9051,7 +8824,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.COUVERTURE.2019",
@@ -9059,7 +8831,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Usage": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9074,7 +8846,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "OCSGE.USAGE",
@@ -9082,7 +8853,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Usage_2002": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9097,16 +8868,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "OCSGE.USAGE.2002",
             "name": "GeoportailFrance.Ocsge_Usage_2002",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Ocsge_Usage_2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9121,7 +8890,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2011",
@@ -9129,7 +8897,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Usage_2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9144,16 +8912,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "OCSGE.USAGE.2014",
             "name": "GeoportailFrance.Ocsge_Usage_2014",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Ocsge_Usage_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9168,7 +8934,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2016",
@@ -9176,7 +8941,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Usage_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9191,7 +8956,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2017",
@@ -9199,7 +8963,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Usage_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9214,7 +8978,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.USAGE.2019",
@@ -9222,7 +8985,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Visu_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9237,7 +9000,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.VISU.2016",
@@ -9245,7 +9007,7 @@
             "TileMatrixSet": "PM"
         },
         "Ocsge_Visu_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9260,7 +9022,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "OCSGE.VISU.2019",
@@ -9268,7 +9029,7 @@
             "TileMatrixSet": "PM"
         },
         "Ofb_Zones_Exclues": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9283,38 +9044,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "OFB.ZONES.EXCLUES",
             "variant": "OFB.ZONES.EXCLUES",
             "name": "GeoportailFrance.Ofb_Zones_Exclues",
             "TileMatrixSet": "PM"
         },
-        "Ofb_Zones_Exclues_Sauf_Toiture": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
-            "attribution": "Geoportail France",
-            "bounds": [
-                [
-                    41.3252,
-                    -5.15047
-                ],
-                [
-                    51.0991,
-                    9.57054
-                ]
-            ],
-            "min_zoom": 6,
-            "max_zoom": 16,
-            "apikey": "transports",
-            "format": "image/png",
-            "style": "OFB.ZONES.EXCLUES.SAUF.TOITURE",
-            "variant": "OFB.ZONES.EXCLUES.SAUF.TOITURE",
-            "name": "GeoportailFrance.Ofb_Zones_Exclues_Sauf_Toiture",
-            "TileMatrixSet": "PM"
-        },
         "Ofb_Zones_Necessitant_Avis_Gestionnaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9329,15 +9066,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "OFB.ZONES.NECESSITANT.AVIS.GESTIONNAIRE",
             "variant": "OFB.ZONES.NECESSITANT.AVIS.GESTIONNAIRE",
             "name": "GeoportailFrance.Ofb_Zones_Necessitant_Avis_Gestionnaire",
             "TileMatrixSet": "PM"
         },
-        "Ortho-edugeo_pyr-png_wld_wm": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Ortho_edugeo_pyr_png_wld_wm": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9352,15 +9088,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHO-EDUGEO_PYR-PNG_WLD_WM",
-            "name": "GeoportailFrance.Ortho-edugeo_pyr-png_wld_wm",
+            "name": "GeoportailFrance.Ortho_edugeo_pyr_png_wld_wm",
             "TileMatrixSet": "PM"
         },
-        "Ortho-express-2020_pyr-jpg_wld_wm_wmts2": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Ortho_express_2020_pyr_jpg_wld_wm_wmts2": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9375,15 +9110,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHO-EXPRESS-2020_PYR-JPG_WLD_WM_WMTS2",
-            "name": "GeoportailFrance.Ortho-express-2020_pyr-jpg_wld_wm_wmts2",
+            "name": "GeoportailFrance.Ortho_express_2020_pyr_jpg_wld_wm_wmts2",
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Ajaccio1975": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9398,7 +9132,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.AJACCIO1975",
@@ -9406,7 +9139,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Ajaccio1990": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9421,7 +9154,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.AJACCIO1990",
@@ -9429,7 +9161,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Arcachon2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9444,7 +9176,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ARCACHON2010",
@@ -9452,7 +9183,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Arras_lens_bethune2008": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9467,7 +9198,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ARRAS-LENS-BETHUNE2008",
@@ -9475,7 +9205,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Belfort_montbelliard1951": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9490,7 +9220,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BELFORT-MONTBELLIARD1951",
@@ -9498,7 +9227,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Berry_sud1950": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9513,7 +9242,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BERRY-SUD1950",
@@ -9521,7 +9249,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Berry_sud1970": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9536,7 +9264,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BERRY-SUD1970",
@@ -9544,7 +9271,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Bethune1963": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9559,7 +9286,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BETHUNE1963",
@@ -9567,7 +9293,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Bethune1964": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9582,7 +9308,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BETHUNE1964",
@@ -9590,7 +9315,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Bethune1988": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9605,7 +9330,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BETHUNE1988",
@@ -9613,7 +9337,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Biarritz1977": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9628,7 +9352,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BIARRITZ1977",
@@ -9636,7 +9359,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Biarrtitz1979": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9651,7 +9374,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BIARRTITZ1979",
@@ -9659,7 +9381,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Bordeaux2003": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9674,7 +9396,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BORDEAUX2003",
@@ -9682,7 +9403,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Bourg_st_maurice1956": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9697,7 +9418,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.BOURG-ST-MAURICE1956",
@@ -9705,7 +9425,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Caen1991": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9720,7 +9440,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAEN1991",
@@ -9728,7 +9447,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Cap_d_agde1968": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9743,7 +9462,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAP-D-AGDE1968",
@@ -9751,7 +9469,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Cap_d_agde2008": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9766,7 +9484,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAP-D-AGDE2008",
@@ -9774,7 +9491,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Cap_dage1981": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9789,7 +9506,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CAP-DAGE1981",
@@ -9797,7 +9513,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Clermont_ferrand1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9812,7 +9528,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CLERMONT-FERRAND1965",
@@ -9820,7 +9535,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Clermont_ferrand1985": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9835,7 +9550,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CLERMONT-FERRAND1985",
@@ -9843,7 +9557,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Creil_sud_picardie1975": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9858,7 +9572,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.CREIL-SUD-PICARDIE1975",
@@ -9866,7 +9579,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Dijon1971": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9881,7 +9594,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.DIJON1971",
@@ -9889,7 +9601,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Grenoble1966": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9904,7 +9616,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GRENOBLE1966",
@@ -9912,7 +9623,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Grenoble1989": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9927,7 +9638,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GRENOBLE1989",
@@ -9935,7 +9645,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Guadeloupe1984": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9950,7 +9660,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GUADELOUPE1984",
@@ -9958,7 +9667,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Guyane1955": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9973,7 +9682,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.GUYANE1955",
@@ -9981,7 +9689,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_La_reunion1961": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -9996,7 +9704,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION1961",
@@ -10004,7 +9711,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_La_reunion1980": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10019,7 +9726,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION1980",
@@ -10027,7 +9733,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_La_reunion1989": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10042,7 +9748,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION1989",
@@ -10050,7 +9755,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_La_reunion2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10065,7 +9770,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-REUNION2010",
@@ -10073,7 +9777,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_La_rochelle_rochefort1973": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10088,7 +9792,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LA-ROCHELLE-ROCHEFORT1973",
@@ -10096,7 +9799,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Le_havre1955": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10111,7 +9814,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LE-HAVRE1955",
@@ -10119,7 +9821,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Le_havre1964": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10134,7 +9836,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LE-HAVRE1964",
@@ -10142,7 +9843,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Le_havre2008": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10157,7 +9858,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LE-HAVRE2008",
@@ -10165,7 +9865,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Limoges1974": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10180,7 +9880,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LIMOGES1974",
@@ -10188,7 +9887,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Lyon1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10203,7 +9902,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON1965",
@@ -10211,7 +9909,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Lyon1984": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10226,7 +9924,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON1984",
@@ -10234,7 +9931,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Lyon1988": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10249,7 +9946,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON1988",
@@ -10257,7 +9953,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Lyon2008": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10272,7 +9968,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.LYON2008",
@@ -10280,7 +9975,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marne_la_vallee1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10295,7 +9990,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARNE-LA-VALLEE1965",
@@ -10303,7 +9997,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marne_la_vallee1977": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10318,7 +10012,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARNE-LA-VALLEE1977",
@@ -10326,7 +10019,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marne_la_vallee1987": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10341,7 +10034,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARNE-LA-VALLEE1987",
@@ -10349,7 +10041,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1969": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10364,7 +10056,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1969",
@@ -10372,7 +10063,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1980": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10387,7 +10078,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1980",
@@ -10395,7 +10085,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1987": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10410,7 +10100,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1987",
@@ -10418,7 +10107,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marseille_martigues1988": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10433,7 +10122,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES1988",
@@ -10441,7 +10129,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Marseille_martigues2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10456,7 +10144,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARSEILLE-MARTIGUES2010",
@@ -10464,7 +10151,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Martinique1988": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10479,7 +10166,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.MARTINIQUE1988",
@@ -10487,7 +10173,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Metz_nancy1982": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10502,7 +10188,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.METZ-NANCY1982",
@@ -10510,7 +10195,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Nantes1971": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10525,7 +10210,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.NANTES1971",
@@ -10533,7 +10217,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Paris1949": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10548,7 +10232,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.PARIS1949",
@@ -10556,7 +10239,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Paris1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10571,7 +10254,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.PARIS1965",
@@ -10579,7 +10261,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Paris2010spot": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10594,7 +10276,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.PARIS2010SPOT",
@@ -10602,7 +10283,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Reims1963": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10617,7 +10298,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS1963",
@@ -10625,7 +10305,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Reims1973": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10640,7 +10320,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS1973",
@@ -10648,7 +10327,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Reims1988": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10663,7 +10342,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS1988",
@@ -10671,7 +10349,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Reims2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10686,7 +10364,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.REIMS2010",
@@ -10694,7 +10371,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Roissy1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10709,7 +10386,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ROISSY1965",
@@ -10717,7 +10393,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Roissy1987": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10732,7 +10408,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.ROISSY1987",
@@ -10740,7 +10415,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Strasbourg1975": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10755,7 +10430,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.STRASBOURG1975",
@@ -10763,7 +10437,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Strasbourg1985": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10778,7 +10452,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.STRASBOURG1985",
@@ -10786,7 +10459,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Strasbourg2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10801,7 +10474,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.STRASBOURG2010",
@@ -10809,7 +10481,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Toulon_hyeres1972": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10824,7 +10496,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.TOULON-HYERES1972",
@@ -10832,7 +10503,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Toulouse1954": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10847,7 +10518,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.TOULOUSE1954",
@@ -10855,7 +10525,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Valee_du_drac2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10870,7 +10540,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VALEE-DU-DRAC2010",
@@ -10878,7 +10547,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Vannes_golfe_du_morbihan1970": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10893,7 +10562,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VANNES-GOLFE-DU-MORBIHAN1970",
@@ -10901,7 +10569,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Versailles1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10916,7 +10584,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VERSAILLES1965",
@@ -10924,7 +10591,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Edugeo_Versailles1989": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10939,7 +10606,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.EDUGEO.VERSAILLES1989",
@@ -10947,7 +10613,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2012": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10962,7 +10628,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2012",
@@ -10970,7 +10635,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2013": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -10985,7 +10650,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2013",
@@ -10993,7 +10657,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11008,7 +10672,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2014",
@@ -11016,7 +10679,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2015": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11031,7 +10694,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2015",
@@ -11039,7 +10701,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11054,7 +10716,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2016",
@@ -11062,7 +10723,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11077,7 +10738,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2017",
@@ -11085,7 +10745,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11100,7 +10760,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2018",
@@ -11108,7 +10767,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11123,7 +10782,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2019",
@@ -11131,7 +10789,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11146,7 +10804,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2020",
@@ -11154,7 +10811,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11169,7 +10826,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2021",
@@ -11177,22 +10833,21 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Pleiades_2022": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
                 [
-                    -21.3733,
-                    -67.7132
+                    -13.0259,
+                    -61.6648
                 ],
                 [
-                    69.3108,
-                    55.7216
+                    51.1117,
+                    45.3136
                 ]
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.PLEIADES.2022",
@@ -11200,7 +10855,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Rapideye_2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11215,7 +10870,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.RAPIDEYE.2010",
@@ -11223,7 +10877,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Rapideye_2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11238,7 +10892,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.RAPIDEYE.2011",
@@ -11246,7 +10899,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2013": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11261,16 +10914,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2013",
             "name": "GeoportailFrance.Orthoimagery_Ortho_sat_Spot_2013",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11285,7 +10936,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2014",
@@ -11293,7 +10943,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2015": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11308,7 +10958,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2015",
@@ -11316,7 +10965,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11331,7 +10980,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2016",
@@ -11339,7 +10987,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11354,7 +11002,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2017",
@@ -11362,7 +11009,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11377,7 +11024,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2018",
@@ -11385,7 +11031,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11400,7 +11046,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2019",
@@ -11408,7 +11053,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11423,7 +11068,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2020",
@@ -11431,7 +11075,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11446,7 +11090,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2021",
@@ -11454,7 +11097,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Ortho_sat_Spot_2023": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11469,7 +11112,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHO-SAT.SPOT.2023",
@@ -11477,7 +11119,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophos_Restrictedareas": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11492,7 +11134,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOS.RESTRICTEDAREAS",
@@ -11500,7 +11141,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_1950_1965": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11515,7 +11156,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.1950-1965",
@@ -11523,7 +11163,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_1965_1980": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11538,7 +11178,6 @@
             ],
             "min_zoom": 3,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BDORTHOHISTORIQUE",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.1965-1980",
@@ -11546,7 +11185,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_1980_1995": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11561,16 +11200,14 @@
             ],
             "min_zoom": 3,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BDORTHOHISTORIQUE",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.1980-1995",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_1980_1995",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Bdortho": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11585,7 +11222,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO",
@@ -11593,7 +11229,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Coast2000": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11608,16 +11244,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.COAST2000",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Coast2000",
-            "TileMatrixSet": "PM",
-            "status": "broken"
+            "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Geneve": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11632,7 +11266,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.GENEVE",
@@ -11640,7 +11273,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ilesdunord": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11655,7 +11288,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ILESDUNORD",
@@ -11663,7 +11295,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11678,7 +11310,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC",
@@ -11686,7 +11317,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_express_2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11701,7 +11332,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2018",
@@ -11709,7 +11339,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_express_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11724,7 +11354,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2019",
@@ -11732,7 +11361,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_express_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11747,7 +11376,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2020",
@@ -11755,7 +11383,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_express_2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11770,7 +11398,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2021",
@@ -11778,7 +11405,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_express_2023": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11793,7 +11420,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC-EXPRESS.2023",
@@ -11801,7 +11427,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2012": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11816,7 +11442,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2012",
@@ -11824,7 +11449,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2013": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11839,7 +11464,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2013",
@@ -11847,7 +11471,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11862,7 +11486,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2014",
@@ -11870,7 +11493,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2015": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11885,7 +11508,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2015",
@@ -11893,7 +11515,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11908,7 +11530,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2016",
@@ -11916,7 +11537,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11931,7 +11552,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2017",
@@ -11939,7 +11559,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11954,7 +11574,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2018",
@@ -11962,7 +11581,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -11977,7 +11596,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2019",
@@ -11985,7 +11603,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Irc_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12000,7 +11618,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.IRC.2020",
@@ -12008,7 +11625,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Low_res_Crs84": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12023,7 +11640,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 12,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.LOW_RES.CRS84",
@@ -12031,7 +11647,7 @@
             "TileMatrixSet": "WGS84G_PO"
         },
         "Orthoimagery_Orthophotos_Ncl": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12046,7 +11662,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.NCL",
@@ -12054,7 +11669,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_asp_pac2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12069,7 +11684,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-ASP_PAC2020",
@@ -12077,7 +11691,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_asp_pac2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12092,7 +11706,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-ASP_PAC2021",
@@ -12100,7 +11713,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_asp_pac2022": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12115,7 +11728,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-ASP_PAC2022",
@@ -12123,7 +11735,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12138,7 +11750,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2017",
@@ -12146,7 +11757,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12161,7 +11772,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2018",
@@ -12169,7 +11779,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12184,7 +11794,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2019",
@@ -12192,7 +11801,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12207,7 +11816,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2020",
@@ -12215,7 +11823,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2021": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12230,7 +11838,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2021",
@@ -12238,7 +11845,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Ortho_express_2023": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12253,7 +11860,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.ORTHO-EXPRESS.2023",
@@ -12261,7 +11867,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Pre_Irma": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12276,7 +11882,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.PRE.IRMA",
@@ -12284,7 +11889,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Rapideye": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12299,7 +11904,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.RAPIDEYE",
@@ -12307,7 +11911,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Socle_asp_2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12322,7 +11926,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.SOCLE-ASP.2018",
@@ -12330,7 +11933,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Spot5": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12345,7 +11948,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.SPOT5",
@@ -12353,7 +11955,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos_Urgence_Alex": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12368,7 +11970,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.URGENCE.ALEX",
@@ -12376,7 +11977,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2000": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12391,7 +11992,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2000",
@@ -12399,7 +11999,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2000_2005": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12414,7 +12014,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2000-2005",
@@ -12422,7 +12021,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2001": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12437,7 +12036,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2001",
@@ -12445,7 +12043,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2002": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12460,7 +12058,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2002",
@@ -12468,7 +12065,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2003": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12483,7 +12080,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2003",
@@ -12491,7 +12087,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2004": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12506,7 +12102,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2004",
@@ -12514,7 +12109,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2005": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12529,7 +12124,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2005",
@@ -12537,7 +12131,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2006": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12552,7 +12146,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2006",
@@ -12560,7 +12153,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2006_2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12575,7 +12168,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2006-2010",
@@ -12583,7 +12175,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2007": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12598,7 +12190,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2007",
@@ -12606,7 +12197,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2008": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12621,7 +12212,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2008",
@@ -12629,7 +12219,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2009": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12644,7 +12234,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2009",
@@ -12652,7 +12241,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12667,7 +12256,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2010",
@@ -12675,7 +12263,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12690,7 +12278,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2011",
@@ -12698,7 +12285,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2011_2015": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12713,7 +12300,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2011-2015",
@@ -12721,7 +12307,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2012": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12736,7 +12322,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2012",
@@ -12744,7 +12329,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2013": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12759,7 +12344,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2013",
@@ -12767,7 +12351,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2014": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12782,7 +12366,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2014",
@@ -12790,7 +12373,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2015": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12805,7 +12388,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2015",
@@ -12813,7 +12395,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2016": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12828,7 +12410,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2016",
@@ -12836,7 +12417,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2017": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12851,7 +12432,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2017",
@@ -12859,7 +12439,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2018": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12874,7 +12454,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2018",
@@ -12882,7 +12461,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2019": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12897,7 +12476,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2019",
@@ -12905,7 +12483,7 @@
             "TileMatrixSet": "PM"
         },
         "Orthoimagery_Orthophotos2020": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12920,7 +12498,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 19,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS2020",
@@ -12928,7 +12505,7 @@
             "TileMatrixSet": "PM"
         },
         "Parking_Sup_500": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12943,7 +12520,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PARKING.SUP.500",
             "variant": "PARKING.SUP.500",
@@ -12951,7 +12527,7 @@
             "TileMatrixSet": "PM"
         },
         "Part_Enr_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12966,7 +12542,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PART.ENR.COMMUNE",
             "variant": "PART.ENR.COMMUNE",
@@ -12974,7 +12549,7 @@
             "TileMatrixSet": "PM"
         },
         "Pcrs_Lamb93": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -12989,16 +12564,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 22,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "PCRS.LAMB93",
             "name": "GeoportailFrance.Pcrs_Lamb93",
-            "TileMatrixSet": "LAMB93_5cm",
-            "status": "broken"
+            "TileMatrixSet": "LAMB93_5cm"
         },
         "Points_Injection_Biomethane": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13012,8 +12585,7 @@
                 ]
             ],
             "min_zoom": 6,
-            "max_zoom": 18,
-            "apikey": "transports",
+            "max_zoom": 16,
             "format": "image/png",
             "style": "POINTS.INJECTION.BIOMETHANE",
             "variant": "POINTS.INJECTION.BIOMETHANE",
@@ -13021,7 +12593,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Eolien_Reglementaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13036,7 +12608,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.EOLIEN.REGLE",
             "variant": "POTENTIEL.EOLIEN.REGLEMENTAIRE",
@@ -13044,7 +12615,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Geothermie": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13059,7 +12630,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.GEOTHERMIE",
             "variant": "POTENTIEL.GEOTHERMIE",
@@ -13067,7 +12637,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Hydro": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13082,7 +12652,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.HYDRO",
             "variant": "POTENTIEL.HYDRO",
@@ -13090,7 +12659,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Reseau_Chaleur_Paca": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13105,7 +12674,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.RESEAU.CHALEUR.PACA",
             "variant": "POTENTIEL.RESEAU.CHALEUR.PACA",
@@ -13113,7 +12681,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Reseau_Chaud_Froid_Paca": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13128,7 +12696,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.RESEAU.CHAUD.FROID.PACA",
             "variant": "POTENTIEL.RESEAU.CHAUD.FROID.PACA",
@@ -13136,7 +12703,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Reseau_Froid_Paca": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13151,7 +12718,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.RESEAU.FROID.PACA",
             "variant": "POTENTIEL.RESEAU.FROID.PACA",
@@ -13159,7 +12725,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Solaire_Batiment": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13174,7 +12740,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.SOLAIRE.BATIMENT",
             "variant": "POTENTIEL.SOLAIRE.BATIMENT",
@@ -13182,7 +12747,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Solaire_Friche": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13197,7 +12762,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.SOLAIRE.FRICHE",
             "variant": "POTENTIEL.SOLAIRE.FRICHE",
@@ -13205,7 +12769,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Solaire_Parking500": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13220,7 +12784,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.SOLAIRE.PARKING500",
             "variant": "POTENTIEL.SOLAIRE.PARKING500",
@@ -13228,7 +12791,7 @@
             "TileMatrixSet": "PM"
         },
         "Potentiel_Solaire_Sol": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13243,7 +12806,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POTENTIEL.SOLAIRE.SOL",
             "variant": "POTENTIEL.SOLAIRE.SOL",
@@ -13251,7 +12813,7 @@
             "TileMatrixSet": "PM"
         },
         "Prairies_Sensibles_Bcae": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13266,7 +12828,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "PRAIRIES.SENSIBLES.BCAE",
@@ -13274,7 +12835,7 @@
             "TileMatrixSet": "PM"
         },
         "Prod_Installation_Eolien": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13289,7 +12850,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROD.INSTALLATION.EOLIEN",
             "variant": "PROD.INSTALLATION.EOLIEN",
@@ -13297,7 +12857,7 @@
             "TileMatrixSet": "PM"
         },
         "Prod_Installation_Hydro": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13312,7 +12872,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROD.INSTALLATION.HYDRO",
             "variant": "PROD.INSTALLATION.HYDRO",
@@ -13320,7 +12879,7 @@
             "TileMatrixSet": "PM"
         },
         "Prod_Installation_Pv": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13335,7 +12894,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROD.INSTALLATION.PV",
             "variant": "PROD.INSTALLATION.PV",
@@ -13343,7 +12901,7 @@
             "TileMatrixSet": "PM"
         },
         "Productible_Biomethane_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13358,7 +12916,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PRODUCTIBLE.BIOMETHANE.COMMUNE",
             "variant": "PRODUCTIBLE.BIOMETHANE.COMMUNE",
@@ -13366,7 +12923,7 @@
             "TileMatrixSet": "PM"
         },
         "Productible_Eolien_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13381,7 +12938,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PRODUCTIBLE.EOLIEN.COMMUNE",
             "variant": "PRODUCTIBLE.EOLIEN.COMMUNE",
@@ -13389,7 +12945,7 @@
             "TileMatrixSet": "PM"
         },
         "Productible_Methanisation_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13404,7 +12960,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PRODUCTIBLE.METHANISATION.COMMUNE",
             "variant": "PRODUCTIBLE.METHANISATION.COMMUNE",
@@ -13412,7 +12967,7 @@
             "TileMatrixSet": "PM"
         },
         "Productible_Photovoltaique_Commune": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13427,7 +12982,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PRODUCTIBLE.PHOTOVOLTAIQUE.COMMUNE",
             "variant": "PRODUCTIBLE.PHOTOVOLTAIQUE.COMMUNE",
@@ -13435,7 +12989,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Apb": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13450,7 +13004,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.APB",
             "variant": "PROTECTEDAREAS.APB",
@@ -13458,7 +13011,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Apg": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13473,7 +13026,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.APG",
@@ -13481,7 +13033,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Aphn": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13496,7 +13048,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.APHN",
@@ -13504,7 +13055,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Aplg": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13519,7 +13070,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "nolegend",
             "variant": "PROTECTEDAREAS.APLG",
@@ -13527,7 +13077,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Bios": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13542,7 +13092,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.BIOS",
             "variant": "PROTECTEDAREAS.BIOS",
@@ -13550,7 +13099,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Gp": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13565,7 +13114,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.GP",
@@ -13573,7 +13121,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Inpg": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13588,7 +13136,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.INPG",
@@ -13596,7 +13143,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Mnhn_Cdl_Parcels": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13611,7 +13158,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.MNHN.CDL.PARCELS",
             "variant": "PROTECTEDAREAS.MNHN.CDL.PARCELS",
@@ -13619,7 +13165,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Mnhn_Cdl_Perimeter": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13634,7 +13180,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.MNHN.CDL.PERIMETER",
@@ -13642,7 +13187,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Mnhn_Conservatoires": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13657,7 +13202,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.MNHN.CONSERVATOIRES",
@@ -13665,7 +13209,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Mnhn_Rn_Perimeter": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13680,7 +13224,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.MNHN.RN.PERIMETER",
@@ -13688,7 +13231,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Pn": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13703,7 +13246,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.PN",
             "variant": "PROTECTEDAREAS.PN",
@@ -13711,7 +13253,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Pnm": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13726,7 +13268,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.PNM",
@@ -13734,7 +13275,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Pnr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13749,7 +13290,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.PNR",
             "variant": "PROTECTEDAREAS.PNR",
@@ -13757,7 +13297,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Prsf": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13772,7 +13312,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "POINT RENCONTRE SECOURS FORET",
             "variant": "PROTECTEDAREAS.PRSF",
@@ -13780,7 +13319,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Ramsar": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13795,7 +13334,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.RAMSAR",
             "variant": "PROTECTEDAREAS.RAMSAR",
@@ -13803,7 +13341,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Rb": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13818,7 +13356,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.RB",
@@ -13826,7 +13363,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Ripn": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13841,7 +13378,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.RIPN",
@@ -13849,7 +13385,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Rn": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13864,7 +13400,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.RN",
             "variant": "PROTECTEDAREAS.RN",
@@ -13872,7 +13407,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Rnc": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13887,7 +13422,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.RNC",
             "variant": "PROTECTEDAREAS.RNC",
@@ -13895,7 +13429,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Rncf": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13910,7 +13444,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.RNCF",
@@ -13918,7 +13451,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Sic": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13933,7 +13466,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.SIC",
             "variant": "PROTECTEDAREAS.SIC",
@@ -13941,7 +13473,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Unesco": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13956,7 +13488,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.UNESCO",
@@ -13964,7 +13495,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Znieff1": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -13979,7 +13510,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.ZNIEFF1",
             "variant": "PROTECTEDAREAS.ZNIEFF1",
@@ -13987,7 +13517,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Znieff1_Sea": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14002,7 +13532,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.ZNIEFF1.SEA",
@@ -14010,7 +13539,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Znieff2": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14025,7 +13554,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.ZNIEFF2",
             "variant": "PROTECTEDAREAS.ZNIEFF2",
@@ -14033,7 +13561,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Znieff2_Sea": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14048,7 +13576,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PROTECTEDAREAS.ZNIEFF2.SEA",
@@ -14056,7 +13583,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Zpr": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14071,7 +13598,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.BIOS",
             "variant": "PROTECTEDAREAS.ZPR",
@@ -14079,7 +13605,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedareas_Zps": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14094,7 +13620,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDAREAS.ZPS",
             "variant": "PROTECTEDAREAS.ZPS",
@@ -14102,7 +13627,7 @@
             "TileMatrixSet": "PM"
         },
         "Protectedsites_Mnhn_Reserves_regionales": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14117,7 +13642,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PROTECTEDSITES.MNHN.RESERVES-REGIONALES",
             "variant": "PROTECTEDSITES.MNHN.RESERVES-REGIONALES",
@@ -14125,7 +13649,7 @@
             "TileMatrixSet": "PM"
         },
         "Puissance_Installee_Biomethane": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14140,7 +13664,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PUISSANCE.INSTALLEE.METHANISATION.BIOMETHANE",
             "variant": "PUISSANCE.INSTALLEE.BIOMETHANE",
@@ -14148,7 +13671,7 @@
             "TileMatrixSet": "PM"
         },
         "Puissance_Installee_Methanisation": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14163,15 +13686,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "PUISSANCE.INSTALLEE.METHANISATION.BIOMETHANE",
             "variant": "PUISSANCE.INSTALLEE.METHANISATION",
             "name": "GeoportailFrance.Puissance_Installee_Methanisation",
             "TileMatrixSet": "PM"
         },
-        "Pva_ign_zone-marais-de-virvee_1945": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Pva_ign_zone_marais_de_virvee_1945": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14186,15 +13708,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BDORTHOHISTORIQUE",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1945",
-            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1945",
+            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1945",
             "TileMatrixSet": "PM"
         },
-        "Pva_ign_zone-marais-de-virvee_1956": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Pva_ign_zone_marais_de_virvee_1956": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14209,15 +13730,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "BDORTHOHISTORIQUE",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1956",
-            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1956",
+            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1956",
             "TileMatrixSet": "PM"
         },
-        "Pva_ign_zone-marais-de-virvee_1976": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Pva_ign_zone_marais_de_virvee_1976": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14232,15 +13752,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1976",
-            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1976",
+            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1976",
             "TileMatrixSet": "PM"
         },
-        "Pva_ign_zone-marais-de-virvee_1984": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Pva_ign_zone_marais_de_virvee_1984": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14255,15 +13774,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "PVA_IGN_zone-marais-de-Virvee_1984",
-            "name": "GeoportailFrance.Pva_ign_zone-marais-de-virvee_1984",
+            "name": "GeoportailFrance.Pva_ign_zone_marais_de_virvee_1984",
             "TileMatrixSet": "PM"
         },
-        "Rapideye_pyr-jpeg_wld_wm_2010": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Rapideye_pyr_jpeg_wld_wm_2010": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14278,15 +13796,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "RAPIDEYE_PYR-JPEG_WLD_WM_2010",
-            "name": "GeoportailFrance.Rapideye_pyr-jpeg_wld_wm_2010",
+            "name": "GeoportailFrance.Rapideye_pyr_jpeg_wld_wm_2010",
             "TileMatrixSet": "PM"
         },
-        "Rapideye_pyr-jpeg_wld_wm_2011": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Rapideye_pyr_jpeg_wld_wm_2011": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14301,15 +13818,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "RAPIDEYE_PYR-JPEG_WLD_WM_2011",
-            "name": "GeoportailFrance.Rapideye_pyr-jpeg_wld_wm_2011",
+            "name": "GeoportailFrance.Rapideye_pyr_jpeg_wld_wm_2011",
             "TileMatrixSet": "PM"
         },
         "Repartition_Potentiel_Methanisation_2050": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14324,15 +13840,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "REPARTITION.POTENTIEL.METHANISATION.2050",
             "variant": "REPARTITION.POTENTIEL.METHANISATION.2050",
             "name": "GeoportailFrance.Repartition_Potentiel_Methanisation_2050",
             "TileMatrixSet": "PM"
         },
-        "Rpg2012_pyr-png_wld_edugeo_20170126": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Rpg2012_pyr_png_wld_edugeo_20170126": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14347,15 +13862,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "RPG2012_PYR-PNG_WLD_EDUGEO_20170126",
-            "name": "GeoportailFrance.Rpg2012_pyr-png_wld_edugeo_20170126",
+            "name": "GeoportailFrance.Rpg2012_pyr_png_wld_edugeo_20170126",
             "TileMatrixSet": "PM"
         },
-        "Scan-edugeo_pyr-png_fxx_wm": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Scan_edugeo_pyr_png_fxx_wm": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14370,15 +13884,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "SCAN-EDUGEO_PYR-PNG_FXX_WM",
-            "name": "GeoportailFrance.Scan-edugeo_pyr-png_fxx_wm",
+            "name": "GeoportailFrance.Scan_edugeo_pyr_png_fxx_wm",
             "TileMatrixSet": "PM"
         },
-        "Scan1000_pyr-jpeg_wld_wm_wmts_3d": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Scan1000_pyr_jpeg_wld_wm_wmts_3d": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14393,38 +13906,14 @@
             ],
             "min_zoom": 0,
             "max_zoom": 10,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "SCAN1000_PYR-JPEG_WLD_WM_WMTS_3D",
-            "name": "GeoportailFrance.Scan1000_pyr-jpeg_wld_wm_wmts_3d",
-            "TileMatrixSet": "PM"
-        },
-        "Scanreg_pyr-jpeg_wld_wm_wmts_3d": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
-            "attribution": "Geoportail France",
-            "bounds": [
-                [
-                    17.9892,
-                    -63.1702
-                ],
-                [
-                    18.1429,
-                    -62.9905
-                ]
-            ],
-            "min_zoom": 0,
-            "max_zoom": 18,
-            "apikey": "transports",
-            "format": "image/png",
-            "style": "normal",
-            "variant": "SCANREG_PYR-JPEG_WLD_WM_WMTS_3D",
-            "name": "GeoportailFrance.Scanreg_pyr-jpeg_wld_wm_wmts_3d",
+            "name": "GeoportailFrance.Scan1000_pyr_jpeg_wld_wm_wmts_3d",
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_1te": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14437,9 +13926,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 4,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "RESEAU ROUTIER 1TE",
             "variant": "SECUROUTE.TE.1TE",
@@ -14447,7 +13935,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_2te48": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14460,9 +13948,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "RESEAU ROUTIER 2TE48",
             "variant": "SECUROUTE.TE.2TE48",
@@ -14470,7 +13957,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_All": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14483,9 +13970,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "TOUS LES FRANCHISSEMENTS",
             "variant": "SECUROUTE.TE.ALL",
@@ -14493,7 +13979,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_Oa": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14506,9 +13992,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "AUTRES FRANCHISSEMENTS",
             "variant": "SECUROUTE.TE.OA",
@@ -14516,7 +14001,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_Pn": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14529,9 +14014,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "FRANCHISSEMENTS PASSAGE A NIVEAU",
             "variant": "SECUROUTE.TE.PN",
@@ -14539,7 +14023,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_Pnd": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14552,9 +14036,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "FRANCHISSEMENTS PASSAGE A NIVEAU DIFFICILE",
             "variant": "SECUROUTE.TE.PND",
@@ -14562,7 +14045,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_Te120": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14575,9 +14058,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "RESEAU ROUTIER TE120",
             "variant": "SECUROUTE.TE.TE120",
@@ -14585,7 +14067,7 @@
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_Te72": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14598,17 +14080,16 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
-            "style": "RESEAU ROUTIER TE72",
+            "style": "RESEAU ROUTIER TE94",
             "variant": "SECUROUTE.TE.TE72",
             "name": "GeoportailFrance.Securoute_Te_Te72",
             "TileMatrixSet": "PM"
         },
         "Securoute_Te_Te94": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14621,9 +14102,8 @@
                     55.9259
                 ]
             ],
-            "min_zoom": 6,
+            "min_zoom": 7,
             "max_zoom": 17,
-            "apikey": "transports",
             "format": "image/png",
             "style": "RESEAU ROUTIER TE94",
             "variant": "SECUROUTE.TE.TE94",
@@ -14631,7 +14111,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Biogaz": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14646,7 +14126,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.BIOGAZ",
             "variant": "SITE.PRODUCTION.CHALEUR.BIOGAZ",
@@ -14654,7 +14133,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Cogeneration": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14669,7 +14148,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.COGENERATION",
             "variant": "SITE.PRODUCTION.CHALEUR.COGENERATION",
@@ -14677,7 +14155,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Dechets": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14692,7 +14170,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.DECHETS",
             "variant": "SITE.PRODUCTION.CHALEUR.DECHETS",
@@ -14700,7 +14177,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Methanisaton": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14715,7 +14192,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.METHANISATON",
             "variant": "SITE.PRODUCTION.CHALEUR.METHANISATON",
@@ -14723,7 +14199,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Rc": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14738,7 +14214,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.RC",
             "variant": "SITE.PRODUCTION.CHALEUR.RC",
@@ -14746,7 +14221,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Rc_Bretagne": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14761,7 +14236,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.RC.BRETAGNE",
             "variant": "SITE.PRODUCTION.CHALEUR.RC.BRETAGNE",
@@ -14769,7 +14243,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Rc_Paca": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14784,7 +14258,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.RC.PACA",
             "variant": "SITE.PRODUCTION.CHALEUR.RC.PACA",
@@ -14792,7 +14265,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Rcf_Lineaire": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14807,7 +14280,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.RCF.LINEAIRE",
             "variant": "SITE.PRODUCTION.CHALEUR.RCF.LINEAIRE",
@@ -14815,7 +14287,7 @@
             "TileMatrixSet": "PM"
         },
         "Site_Production_Chaleur_Rcf_Point": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14830,15 +14302,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "SITE.PRODUCTION.CHALEUR.RCF.POINT",
             "variant": "SITE.PRODUCTION.CHALEUR.RCF.POINT",
             "name": "GeoportailFrance.Site_Production_Chaleur_Rcf_Point",
             "TileMatrixSet": "PM"
         },
-        "Spot-edugeo_pyr-png_wld_wm": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Spot_edugeo_pyr_png_wld_wm": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14853,15 +14324,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "SPOT-EDUGEO_PYR-PNG_WLD_WM",
-            "name": "GeoportailFrance.Spot-edugeo_pyr-png_wld_wm",
+            "name": "GeoportailFrance.Spot_edugeo_pyr_png_wld_wm",
             "TileMatrixSet": "PM"
         },
-        "Spot5_pyr-jpeg_wld_wm": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+        "Spot5_pyr_jpeg_wld_wm": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14876,15 +14346,14 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "SPOT5_PYR-JPEG_WLD_WM",
-            "name": "GeoportailFrance.Spot5_pyr-jpeg_wld_wm",
+            "name": "GeoportailFrance.Spot5_pyr_jpeg_wld_wm",
             "TileMatrixSet": "PM"
         },
         "Test_pbe_le_havre": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14899,7 +14368,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TEST_PBE_LE_HAVRE",
@@ -14907,7 +14375,7 @@
             "TileMatrixSet": "PM"
         },
         "Thr_Orthoimagery_Orthophotos": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14922,7 +14390,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 20,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "THR.ORTHOIMAGERY.ORTHOPHOTOS",
@@ -14930,7 +14397,7 @@
             "TileMatrixSet": "PM"
         },
         "Traces_Rando_Hivernale": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14945,7 +14412,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRACES.RANDO.HIVERNALE",
@@ -14953,7 +14419,7 @@
             "TileMatrixSet": "PM"
         },
         "Transportnetwork_Commontransportelements_Markerpost": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14968,7 +14434,6 @@
             ],
             "min_zoom": 10,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTNETWORK.COMMONTRANSPORTELEMENTS.MARKERPOST",
@@ -14976,7 +14441,7 @@
             "TileMatrixSet": "PM"
         },
         "Transportnetwork_Commontransportelements_Markerpost_visu": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -14991,7 +14456,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTNETWORK.COMMONTRANSPORTELEMENTS.MARKERPOST_VISU",
@@ -14999,7 +14463,7 @@
             "TileMatrixSet": "PM"
         },
         "Transportnetworks_Railways": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15014,7 +14478,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.RAILWAYS",
@@ -15022,7 +14485,7 @@
             "TileMatrixSet": "PM"
         },
         "Transportnetworks_Roads": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15037,7 +14500,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.ROADS",
@@ -15045,7 +14507,7 @@
             "TileMatrixSet": "PM"
         },
         "Transportnetworks_Roads_Direction": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15060,7 +14522,6 @@
             ],
             "min_zoom": 15,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.ROADS.DIRECTION",
@@ -15068,7 +14529,7 @@
             "TileMatrixSet": "PM"
         },
         "Transportnetworks_Runways": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15083,7 +14544,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTNETWORKS.RUNWAYS",
@@ -15091,7 +14551,7 @@
             "TileMatrixSet": "PM"
         },
         "Transports_Drones_Restrictions": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15106,7 +14566,6 @@
             ],
             "min_zoom": 3,
             "max_zoom": 15,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "TRANSPORTS.DRONES.RESTRICTIONS",
@@ -15114,7 +14573,7 @@
             "TileMatrixSet": "PM"
         },
         "Utilityandgovernmentalservices_All": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15129,7 +14588,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "UTILITYANDGOVERNMENTALSERVICES.ALL",
@@ -15137,7 +14595,7 @@
             "TileMatrixSet": "PM"
         },
         "Zonage_Ofb": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15152,7 +14610,6 @@
             ],
             "min_zoom": 6,
             "max_zoom": 16,
-            "apikey": "transports",
             "format": "image/png",
             "style": "ZONAGE.OFB",
             "variant": "ZONAGE.OFB",
@@ -15160,7 +14617,7 @@
             "TileMatrixSet": "PM"
         },
         "Hedge_Hedge": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15175,7 +14632,6 @@
             ],
             "min_zoom": 7,
             "max_zoom": 18,
-            "apikey": "transports",
             "format": "image/png",
             "style": "normal",
             "variant": "hedge.hedge",
@@ -15183,7 +14639,7 @@
             "TileMatrixSet": "PM"
         },
         "Tuto_scan1000_srd": {
-            "url": "https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
             "attribution": "Geoportail France",
             "bounds": [
@@ -15198,7 +14654,6 @@
             ],
             "min_zoom": 0,
             "max_zoom": 10,
-            "apikey": "transports",
             "format": "image/jpeg",
             "style": "normal",
             "variant": "tuto_scan1000_SRD",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -8852,7 +8852,8 @@
             "variant": "OCSGE.CONSTRUCTIONS.2002",
             "name": "GeoportailFrance.Ocsge_Constructions_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Constructions_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -8898,7 +8899,8 @@
             "variant": "OCSGE.CONSTRUCTIONS.2014",
             "name": "GeoportailFrance.Ocsge_Constructions_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Constructions_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9013,7 +9015,8 @@
             "variant": "OCSGE.COUVERTURE.2002",
             "name": "GeoportailFrance.Ocsge_Couverture_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Couverture_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9059,7 +9062,8 @@
             "variant": "OCSGE.COUVERTURE.2014",
             "name": "GeoportailFrance.Ocsge_Couverture_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Couverture_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9174,7 +9178,8 @@
             "variant": "OCSGE.USAGE.2002",
             "name": "GeoportailFrance.Ocsge_Usage_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Usage_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9220,7 +9225,8 @@
             "variant": "OCSGE.USAGE.2014",
             "name": "GeoportailFrance.Ocsge_Usage_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Usage_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -11658,7 +11664,8 @@
             "variant": "ORTHOIMAGERY.ORTHOPHOTOS.COAST2000",
             "name": "GeoportailFrance.Orthoimagery_Orthophotos_Coast2000",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Orthoimagery_Orthophotos_Geneve": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13038,7 +13045,8 @@
             "variant": "PCRS.LAMB93",
             "name": "GeoportailFrance.Pcrs_Lamb93",
             "TileMatrixSet": "LAMB93_5cm",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Points_Injection_Biomethane": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -2599,7 +2599,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb63k1885",
-            "name": "NLS.osgb63k1885"
+            "name": "NLS.osgb63k1885",
+            "apikey": "<insert your API key here>"
         },
         "osgb1888": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2618,7 +2619,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb1888",
-            "name": "NLS.osgb1888"
+            "name": "NLS.osgb1888",
+            "apikey": "<insert your API key here>"
         },
         "osgb10k1888": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2637,7 +2639,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb10k1888",
-            "name": "NLS.osgb10k1888"
+            "name": "NLS.osgb10k1888",
+            "apikey": "<insert your API key here>"
         },
         "osgb1919": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2656,7 +2659,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb1919",
-            "name": "NLS.osgb1919"
+            "name": "NLS.osgb1919",
+            "apikey": "<insert your API key here>"
         },
         "osgb25k1937": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2675,7 +2679,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb25k1937",
-            "name": "NLS.osgb25k1937"
+            "name": "NLS.osgb25k1937",
+            "apikey": "<insert your API key here>"
         },
         "osgb63k1955": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
@@ -2694,7 +2699,8 @@
             "min_zoom": 1,
             "max_zoom": 18,
             "variant": "uk-osgb63k1955",
-            "name": "NLS.osgb63k1955"
+            "name": "NLS.osgb63k1955",
+            "apikey": "<insert your API key here>"
         },
         "oslondon1k1893": {
             "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -9152,7 +9152,8 @@
             "variant": "OCSGE.USAGE.2002",
             "name": "GeoportailFrance.Ocsge_Usage_2002",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Usage_2011": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -9199,7 +9200,8 @@
             "variant": "OCSGE.USAGE.2014",
             "name": "GeoportailFrance.Ocsge_Usage_2014",
             "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Ocsge_Usage_2016": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
@@ -13020,7 +13022,8 @@
             "variant": "PCRS.LAMB93",
             "name": "GeoportailFrance.Pcrs_Lamb93",
             "TileMatrixSet": "LAMB93_5cm",
-            "apikey": "your_api_key_here"
+            "apikey": "your_api_key_here",
+            "status": "broken"
         },
         "Points_Injection_Biomethane": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",

--- a/xyzservices/tests/test_lib.py
+++ b/xyzservices/tests/test_lib.py
@@ -179,18 +179,6 @@ def test_copy(basic_provider):
     assert isinstance(basic2, TileProvider)
 
 
-def test_callable():
-    # only testing the callable functionality to override a keyword, as we
-    # cannot test the actual providers that need an API key
-    original_key = str(xyz.GeoportailFrance.plan["apikey"])
-    updated_provider = xyz.GeoportailFrance.plan(apikey="mykey")
-    assert isinstance(updated_provider, TileProvider)
-    assert "url" in updated_provider
-    assert updated_provider["apikey"] == "mykey"
-    # check that original provider dict is not modified
-    assert xyz.GeoportailFrance.plan["apikey"] == original_key
-
-
 def test_html_attribution_fallback(basic_provider, html_attr_provider):
     # TileProvider.html_attribution falls back to .attribution if the former not present
     assert basic_provider.html_attribution == basic_provider.attribution

--- a/xyzservices/tests/test_lib.py
+++ b/xyzservices/tests/test_lib.py
@@ -179,6 +179,18 @@ def test_copy(basic_provider):
     assert isinstance(basic2, TileProvider)
 
 
+def test_callable():
+    # only testing the callable functionality to override a keyword, as we
+    # cannot test the actual providers that need an API key
+    original_key = str(xyz.OpenWeatherMap.CloudsClassic["apiKey"])
+    updated_provider = xyz.OpenWeatherMap.CloudsClassic(apiKey="mykey")
+    assert isinstance(updated_provider, TileProvider)
+    assert "url" in updated_provider
+    assert updated_provider["apiKey"] == "mykey"
+    # check that original provider dict is not modified
+    assert xyz.OpenWeatherMap.CloudsClassic["apiKey"] == original_key
+
+
 def test_html_attribution_fallback(basic_provider, html_attr_provider):
     # TileProvider.html_attribution falls back to .attribution if the former not present
     assert basic_provider.html_attribution == basic_provider.attribution


### PR DESCRIPTION
#165 
This PR migrates the ign WMTS services to the new service: `https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities`

The new services don't have a categorizing key, like agriculture...
So I removed the apiKey as well as its test.

Edit
The test_callable is actually needed.

