### PR TITLE
Add quarterly basemap imagery from Planet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# Pycharm project settings
+.idea/
+
 # mkdocs documentation
 /site
 

--- a/provider_sources/xyzservices-providers.json
+++ b/provider_sources/xyzservices-providers.json
@@ -544,5 +544,304 @@
             ],
             "name": "OrdnanceSurvey.Leisure_27700"
         }
+    },
+    "Planet": {
+        "QuarterlyBasemaps2016q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q1"
+        },
+        "QuarterlyBasemaps2016q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q2"
+        },
+        "QuarterlyBasemaps2016q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q3"
+        },
+        "QuarterlyBasemaps2016q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q4"
+        },
+        "QuarterlyBasemaps2017q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q1"
+        },
+        "QuarterlyBasemaps2017q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q2"
+        },
+        "QuarterlyBasemaps2017q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q3"
+        },
+        "QuarterlyBasemaps2017q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q4"
+        },
+        "QuarterlyBasemaps2018q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q1"
+        },
+        "QuarterlyBasemaps2018q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q2"
+        },
+        "QuarterlyBasemaps2018q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q3"
+        },
+        "QuarterlyBasemaps2018q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q4"
+        },
+        "QuarterlyBasemaps2019q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q1"
+        },
+        "QuarterlyBasemaps2019q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q2"
+        },
+        "QuarterlyBasemaps2019q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q3"
+        },
+        "QuarterlyBasemaps2019q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q4"
+        },
+        "QuarterlyBasemaps2020q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q1"
+        },
+        "QuarterlyBasemaps2020q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q2"
+        },
+        "QuarterlyBasemaps2020q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q3"
+        },
+        "QuarterlyBasemaps2020q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q4"
+        },
+        "QuarterlyBasemaps2021q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q1"
+        },
+        "QuarterlyBasemaps2021q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q2"
+        },
+        "QuarterlyBasemaps2021q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q3"
+        },
+        "QuarterlyBasemaps2021q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q4"
+        },
+        "QuarterlyBasemaps2022q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q1"
+        },
+        "QuarterlyBasemaps2022q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q2"
+        },
+        "QuarterlyBasemaps2022q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q3"
+        },
+        "QuarterlyBasemaps2022q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q4"
+        },
+        "QuarterlyBasemaps2023q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q1"
+        },
+        "QuarterlyBasemaps2023q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q2",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q2"
+        },
+        "QuarterlyBasemaps2023q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q3",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q3"
+        },
+        "QuarterlyBasemaps2023q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q4",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q4"
+        },
+        "QuarterlyBasemaps2024q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2024q1",
+            "attribution": "© {year} Planet Labs PBC. All rights reserved",
+            "html_attribution": "© <a href=\"https://www.planet.com/\"> {year} Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2024q1"
+        }
     }
 }

--- a/xyzservices/data/providers.json
+++ b/xyzservices/data/providers.json
@@ -9408,6 +9408,29 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
+        "Ofb_Zones_Exclues_Sauf_Toiture": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "attribution": "Geoportail France",
+            "bounds": [
+                [
+                    41.3252,
+                    -5.15047
+                ],
+                [
+                    51.0991,
+                    9.57054
+                ]
+            ],
+            "min_zoom": 6,
+            "max_zoom": 16,
+            "format": "image/png",
+            "style": "OFB.ZONES.EXCLUES.SAUF.TOITURE",
+            "variant": "OFB.ZONES.EXCLUES.SAUF.TOITURE",
+            "name": "GeoportailFrance.Ofb_Zones_Exclues_Sauf_Toiture",
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
+        },
         "Ofb_Zones_Necessitant_Avis_Gestionnaire": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
@@ -13343,6 +13366,29 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
+        "Potentiel_Solaire_Rrn": {
+            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
+            "attribution": "Geoportail France",
+            "bounds": [
+                [
+                    41.3252,
+                    -5.15047
+                ],
+                [
+                    51.0991,
+                    9.57054
+                ]
+            ],
+            "min_zoom": 6,
+            "max_zoom": 16,
+            "format": "image/png",
+            "style": "POTENTIEL.SOLAIRE.RRN",
+            "variant": "POTENTIEL.SOLAIRE.RRN",
+            "name": "GeoportailFrance.Potentiel_Solaire_Rrn",
+            "TileMatrixSet": "PM",
+            "apikey": "your_api_key_here"
+        },
         "Potentiel_Solaire_Sol": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
@@ -15229,29 +15275,6 @@
             "TileMatrixSet": "PM",
             "apikey": "your_api_key_here"
         },
-        "Zonage_Ofb": {
-            "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-            "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
-            "attribution": "Geoportail France",
-            "bounds": [
-                [
-                    -21.4756,
-                    -63.3725
-                ],
-                [
-                    51.3121,
-                    55.9259
-                ]
-            ],
-            "min_zoom": 6,
-            "max_zoom": 16,
-            "format": "image/png",
-            "style": "ZONAGE.OFB",
-            "variant": "ZONAGE.OFB",
-            "name": "GeoportailFrance.Zonage_Ofb",
-            "TileMatrixSet": "PM",
-            "apikey": "your_api_key_here"
-        },
         "Hedge_Hedge": {
             "url": "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE={style}&TILEMATRIXSET={TileMatrixSet}&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
             "html_attribution": "<a target=\"_blank\"href=\"https://www.geoportail.gouv.fr/\">Geoportail France</a>",
@@ -15856,6 +15879,305 @@
                 ]
             ],
             "name": "OrdnanceSurvey.Leisure_27700"
+        }
+    },
+    "Planet": {
+        "QuarterlyBasemaps2016q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q1"
+        },
+        "QuarterlyBasemaps2016q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q2"
+        },
+        "QuarterlyBasemaps2016q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q3"
+        },
+        "QuarterlyBasemaps2016q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2016q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2016q4"
+        },
+        "QuarterlyBasemaps2017q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q1"
+        },
+        "QuarterlyBasemaps2017q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q2"
+        },
+        "QuarterlyBasemaps2017q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q3"
+        },
+        "QuarterlyBasemaps2017q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2017q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2017q4"
+        },
+        "QuarterlyBasemaps2018q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q1"
+        },
+        "QuarterlyBasemaps2018q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q2"
+        },
+        "QuarterlyBasemaps2018q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q3"
+        },
+        "QuarterlyBasemaps2018q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2018q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2018q4"
+        },
+        "QuarterlyBasemaps2019q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q1"
+        },
+        "QuarterlyBasemaps2019q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q2"
+        },
+        "QuarterlyBasemaps2019q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q3"
+        },
+        "QuarterlyBasemaps2019q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2019q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2019q4"
+        },
+        "QuarterlyBasemaps2020q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q1"
+        },
+        "QuarterlyBasemaps2020q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q2"
+        },
+        "QuarterlyBasemaps2020q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q3"
+        },
+        "QuarterlyBasemaps2020q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2020q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2020q4"
+        },
+        "QuarterlyBasemaps2021q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q1"
+        },
+        "QuarterlyBasemaps2021q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q2"
+        },
+        "QuarterlyBasemaps2021q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q3"
+        },
+        "QuarterlyBasemaps2021q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2021q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2021q4"
+        },
+        "QuarterlyBasemaps2022q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q1"
+        },
+        "QuarterlyBasemaps2022q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q2"
+        },
+        "QuarterlyBasemaps2022q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q3"
+        },
+        "QuarterlyBasemaps2022q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2022q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2022q4"
+        },
+        "QuarterlyBasemaps2023q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q1"
+        },
+        "QuarterlyBasemaps2023q2": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q2",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q2"
+        },
+        "QuarterlyBasemaps2023q3": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q3",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q3"
+        },
+        "QuarterlyBasemaps2023q4": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2023q4",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2023q4"
+        },
+        "QuarterlyBasemaps2024q1": {
+            "url": "https://tiles.planet.com/basemaps/v1/planet-tiles/global_quarterly_{quarter}_mosaic/{z}/{x}/{y}.png?api_key={api_key}",
+            "api_key": "<insert your Planet API key here>",
+            "max_zoom": 15,
+            "quarter": "2024q1",
+            "attribution": "\u00a9 2024 Planet Labs PBC. All rights reserved",
+            "html_attribution": "\u00a9 <a href=\"https://www.planet.com/\"> 2024 Planet Labs PBC. All rights reserved</a>",
+            "name": "Planet.QuarterlyBasemaps2024q1"
         }
     }
 }


### PR DESCRIPTION
This PR:

- Adds pycharm settings to the gitignore (don't want to contribute my ide cruft :slightly_smiling_face: )
- Adds all available quarterly basemaps from [Planet labs](https://www.planet.com/) from their xyz service to provider_sources/xyzservices-providers.json
- Updates `xyzservices/data/providers.json` with `make compress`

`make compress` also added two new sources ( "Ofb_Zones_Exclues_Sauf_Toiture" and "Potentiel_Solaire_Rrn") and removed one ("Zonage_Ofb"), I presume because it makes some live requests in the compression script to find WMTS services.

I have manually validated that I get the appropriate error when requesting tiles without an api key:
![image](https://github.com/geopandas/xyzservices/assets/6313865/540d15d2-d192-4532-abab-95ee353bf18f)


I have verified I can pull through tiles for all added sources:

```python
years = list(range(2016, 2025))
quarters = [1, 2, 3, 4]

fig, axes = plt.subplots(figsize=(3*len(years), 3*len(quarters)), nrows=len(quarters), ncols=len(years))

for col, year in enumerate(years):
    for row, quarter in enumerate(quarters):    
        ax = axes[row, col]
        if year == 2024 and quarter > 1:
            ax.set_axis_off()
            continue        
        
        ethiopia.iloc[[0]].boundary.plot(ax=ax)        
        cx.add_basemap(ax, source=xyz.providers.Planet[f"QuarterlyBasemaps{year}q{quarter}"](api_key=planet_api_key))

        if not row:
            ax.set_title(year, fontsize=18)
        if not col:
            ax.set_ylabel(f"Q{quarter}", fontsize=18)

        strip_axes(ax)

fig.tight_layout()
```

![image](https://github.com/geopandas/xyzservices/assets/6313865/22a1d41c-8300-462a-ac5e-97b9c1dd3c20)



