### PR TITLE
Add Bunch methods to allow live updates and loading from json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Pycharm files
+.idea/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/xyzservices/lib.py
+++ b/xyzservices/lib.py
@@ -45,10 +45,7 @@ class Bunch(dict):
 
     @classmethod
     def from_json(cls, f):
-        data = json.loads(f)
-        providers = Bunch()
-        providers.update(**data)
-        return providers
+        return cls(**json.loads(f))
 
     def __getattr__(self, key):
         try:

--- a/xyzservices/providers.py
+++ b/xyzservices/providers.py
@@ -2,7 +2,7 @@ import os
 import pkgutil
 import sys
 
-from .lib import _load_json
+from .lib import Bunch
 
 data_path = os.path.join(sys.prefix, "share", "xyzservices", "providers.json")
 
@@ -12,4 +12,4 @@ if os.path.exists(data_path):
 else:
     json = pkgutil.get_data("xyzservices", "data/providers.json")
 
-providers = _load_json(json)
+providers = Bunch.from_json(json)


### PR DESCRIPTION
This is a request for feedback to address #12  and #14 as it _technically_ has some breaking api changes and I'm unsure what kinds of guarantees you have with downstream users.  

**New Features**

- `Bunch(**correctly_formatted_provider_dict)` now makes a providers object from whatever's in the dict.
- `providers[new_provider_name] = new_provider` now works whenever `new_provider_name` is a str and `new_provider` is a `Bunch`, a `TileProvider` or a correctly formatted dict representing a Bunch or TileProvider
- `providers.update(**{provider_name: new_provider, ...})` Now works wherever `provider_name` and `new_provider` match the `__setitem__` criteria.
- Bunch.from_json(json_string) now does the work of the `_load_json` function.  We could reasonably make this also load json files or ditch the method entirely and have `providers.py` make the json.loads call.

**Breaking changes**

- `__init__`, `__setitem__` and `update` no longer function like their `dict` counterparts for the `Bunch` class.  I'd be suprised if anyone depended on this functionality though. 
- `isinstance(TileProvider, Bunch)` is no longer true, and `TileProvider` no longer has access to `Bunch` methods, consequently.  Instead, `TileProvider` directly inherits from `dict` and implements it's own copy of `__getattr__`.  I think this is technically more in line with what you want, but may have consequences I can't see.

**Other thoughts**

If you can provide more guidance about downstream use cases, I think it would be worth making the following adjustments:

- Changing the base type of `Bunch` from `dict` to `collections.UserDict[str, Bunch | TileProvider]` and adding in appropriate runtime validation to ensure it stays consistent
- Changing the base type of `TileProvider` to either a `pydantic.BaseModel` or a `UserDict[str, str | int]` and providing validation for required and optional fields.  

I think both changes would provide better usability (ie would fail fast and noisily) if downstream users are adding their own sources and formatting them poorly.  