### PR TITLE
Update and apply latest ruff, update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
+autoupdate_schedule: 'monthly'
+
 files: 'xyzservices\/'
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.2.0"
+    rev: "v0.5.1"
     hooks:
       - id: ruff
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-autoupdate_schedule: 'monthly'
+autoupdate_schedule: 'quarterly'
 
 files: 'xyzservices\/'
 repos:

--- a/provider_sources/_parse_leaflet_providers.py
+++ b/provider_sources/_parse_leaflet_providers.py
@@ -11,6 +11,7 @@ It accesses the defined TileLayer.Providers objects through javascript
 using Selenium as JSON, and then processes this a fully specified
 javascript-independent dictionary and saves that final result as a JSON file.
 """
+
 import datetime
 import json
 import os
@@ -87,9 +88,7 @@ def process_provider(data, name="OpenStreetMap"):
             variant_options = variant_keys.pop("options", {})
             variant_keys = {**variant_keys, **variant_options}
         variant_keys = {**provider_keys, **variant_keys}
-        variant_keys["name"] = "{provider}.{variant}".format(
-            provider=name, variant=variant
-        )
+        variant_keys["name"] = f"{name}.{variant}"
         variant_keys = pythonize_data(variant_keys)
         result[variant] = variant_keys
 

--- a/xyzservices/lib.py
+++ b/xyzservices/lib.py
@@ -1,6 +1,7 @@
 """
 Utilities to support XYZservices
 """
+
 from __future__ import annotations
 
 import json

--- a/xyzservices/tests/test_lib.py
+++ b/xyzservices/tests/test_lib.py
@@ -238,9 +238,7 @@ def test_filter(test_bunch):
     def custom(provider):
         if hasattr(provider, "subdomains") and provider.subdomains == "abcd":
             return True
-        if hasattr(provider, "r"):
-            return True
-        return False
+        return bool(hasattr(provider, "r"))
 
     assert len(test_bunch.filter(function=custom).flatten()) == 2
 


### PR DESCRIPTION
This PR does two things:
- pre-commit: Update to latest ruff, set autoupdate schedule to monthly
- Apply latest ruff and ruff-format

I can highly recommend enabling and using https://pre-commit.ci/, it will not only run pre-commit very fast, it will also periodically check if there are any updates available to the pre-commit configuration.